### PR TITLE
Replace `AssetUuid` and `AssetTypeId` with newtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ version = "0.1.0"
 dependencies = [
  "asset-uuid 0.1.0",
  "proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
  "amethyst_error 0.2.0 (git+https://github.com/kabergstrom/amethyst.git?branch=new-asset-system)",
  "atelier-importer 0.1.0 (git+https://github.com/amethyst/atelier-assets.git)",
  "atelier-loader 0.1.0 (git+https://github.com/amethyst/atelier-assets.git)",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -257,7 +257,7 @@ source = "git+https://github.com/kabergstrom/amethyst.git?branch=new-asset-syste
 dependencies = [
  "amethyst_core 0.7.0 (git+https://github.com/kabergstrom/amethyst.git?branch=new-asset-system)",
  "amethyst_error 0.2.0 (git+https://github.com/kabergstrom/amethyst.git?branch=new-asset-system)",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "err-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "laminar 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -480,8 +480,10 @@ name = "atelier-core"
 version = "0.1.0"
 dependencies = [
  "asset-uuid 0.1.0",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -493,7 +495,7 @@ dependencies = [
  "atelier-core 0.1.0",
  "atelier-importer 0.1.0",
  "atelier-schema 0.1.0",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnp 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnp-rpc 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -527,7 +529,7 @@ version = "0.1.0"
 source = "git+https://github.com/amethyst/atelier-assets.git#b876aa31dd81829b59b519788f3c3b20ff72eb5f"
 dependencies = [
  "atelier-core 0.1.0 (git+https://github.com/amethyst/atelier-assets.git)",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "inventory 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mopa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -544,7 +546,7 @@ name = "atelier-importer"
 version = "0.1.0"
 dependencies = [
  "atelier-core 0.1.0",
- "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "inventory 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "mopa 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -667,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.1.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4998,7 +5000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9f04a5e50dc80b3d5d35320889053637d15011aed5e66b66b37ae798c65da6f7"
+"checksum bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8ab639324e3ee8774d296864fbc0dbbb256cf1a41c490b94cba90c082915f92"
 "checksum bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b242e11a8f446f5fc7b76b37e81d737cabca562a927bd33766dac55b5f1177f"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2b_simd 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bf775a81bb2d464e20ff170ac20316c7b08a43d11dbc72f0f82e8e8d3d6d0499"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 uuid = "0.7"
 proc-macro-hack = "0.5"
 asset-uuid = { path = "./asset-uuid" }
+serde = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,3 +8,7 @@ uuid = "0.7"
 proc-macro-hack = "0.5"
 asset-uuid = { path = "./asset-uuid" }
 serde = "1.0"
+
+[dev-dependencies]
+serde_json = "1.0"
+bincode = "1.2"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,10 @@
 use proc_macro_hack::proc_macro_hack;
+use serde::{Serialize, Deserialize, Serializer, Deserializer};
+use serde::de::{self, Visitor};
+use uuid;
+
+use std::{cmp, fmt};
+use std::str::FromStr;
 
 #[proc_macro_hack]
 pub use asset_uuid::asset_uuid;
@@ -7,6 +13,101 @@ pub mod utils;
 /// A universally unique identifier for an asset.
 /// An asset can be an instance of any Rust type that implements
 /// [type_uuid::TypeUuid] + [serde::Serialize] + [Send].
-pub type AssetUuid = [u8; 16];
+///
+/// Serializes to a hyphenated UUID format and deserializes from any format supported by the `uuid`
+/// crate.
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Default, Hash)]
+pub struct AssetUuid(pub [u8; 16]);
+
+impl AsMut<[u8]> for AssetUuid {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for AssetUuid {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl PartialOrd for AssetUuid {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Serialize for AssetUuid {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&uuid::Uuid::from_bytes(self.0).to_string())
+    }
+}
+
+struct AssetUuidVisitor;
+
+impl<'a> Visitor<'a> for AssetUuidVisitor {
+    type Value = AssetUuid;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "a UUID-formatted string")
+    }
+
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
+        uuid::Uuid::from_str(s)
+            .map(|id| AssetUuid(*id.as_bytes()))
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(s), &self))
+    }
+}
+
+impl<'de> Deserialize<'de> for AssetUuid {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_string(AssetUuidVisitor)
+    }
+}
+
 /// UUID of an asset's Rust type. Produced by [type_uuid::TypeUuid::UUID].
-pub type AssetTypeId = [u8; 16];
+///
+/// Serializes to a hyphenated UUID format and deserializes from any format supported by the `uuid`
+/// crate.
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Default, Hash)]
+pub struct AssetTypeId(pub [u8; 16]);
+
+impl AsMut<[u8]> for AssetTypeId {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
+impl AsRef<[u8]> for AssetTypeId {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Serialize for AssetTypeId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&uuid::Uuid::from_bytes(self.0).to_string())
+    }
+}
+
+struct AssetTypeIdVisitor;
+
+impl<'a> Visitor<'a> for AssetTypeIdVisitor {
+    type Value = AssetTypeId;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "a UUID-formatted string")
+    }
+
+    fn visit_str<E: de::Error>(self, s: &str) -> Result<Self::Value, E> {
+        uuid::Uuid::parse_str(s)
+            .map(|id| AssetTypeId(*id.as_bytes()))
+            .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(s), &self))
+    }
+}
+
+impl<'de> Deserialize<'de> for AssetTypeId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_string(AssetTypeIdVisitor)
+    }
+}

--- a/core/tests/uuid.rs
+++ b/core/tests/uuid.rs
@@ -1,0 +1,89 @@
+extern crate atelier_core;
+extern crate serde_json;
+extern crate bincode;
+
+#[test]
+fn serialize_asset_uuid_string() {
+    let uuid = atelier_core::AssetUuid([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+
+    let result = serde_json::to_string(&uuid).unwrap();
+
+    assert_eq!("\"01020304-0506-0708-090a-0b0c0d0e0f10\"".to_string(), result);
+}
+
+#[test]
+fn serialize_asset_uuid_binary() {
+    let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let uuid = atelier_core::AssetUuid(data);
+
+    let result: Vec<u8> = bincode::serialize(&uuid).unwrap();
+
+    assert_eq!(data.to_vec(), result);
+}
+
+#[test]
+fn deserialize_asset_uuid_string() {
+    let string = "\"01020304-0506-0708-090a-0b0c0d0e0f10\"";
+
+    let result: atelier_core::AssetUuid = serde_json::from_str(string).unwrap();
+
+    let expected = atelier_core::AssetUuid([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ]);
+
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn deserialize_asset_uuid_binary() {
+    let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+    let result: atelier_core::AssetUuid = bincode::deserialize(&data).unwrap();
+
+    assert_eq!(atelier_core::AssetUuid(data), result);
+}
+
+#[test]
+fn serialize_type_uuid_string() {
+    let uuid = atelier_core::AssetTypeId([
+        3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3,
+    ]);
+
+    let result = serde_json::to_string(&uuid).unwrap();
+
+    assert_eq!("\"03010401-0509-0206-0503-050809070903\"".to_string(), result);
+}
+
+#[test]
+fn serialize_type_uuid_binary() {
+    let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    let uuid = atelier_core::AssetTypeId(data);
+
+    let result: Vec<u8> = bincode::serialize(&uuid).unwrap();
+
+    assert_eq!(data.to_vec(), result);
+}
+
+#[test]
+fn deserialize_type_uuid_string() {
+    let string = "\"03010401-0509-0206-0503-050809070903\"";
+
+    let result: atelier_core::AssetTypeId = serde_json::from_str(string).unwrap();
+
+    let expected = atelier_core::AssetTypeId([
+        3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3,
+    ]);
+
+    assert_eq!(expected, result);
+}
+
+#[test]
+fn deserialize_type_uuid_binary() {
+    let data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3];
+
+    let result: atelier_core::AssetTypeId = bincode::deserialize(&data).unwrap();
+
+    assert_eq!(atelier_core::AssetTypeId(data), result);
+}

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -6,7 +6,7 @@ use crate::{
     file_tracker::FileTracker,
     serialized_asset::SerializedAsset,
 };
-use atelier_core::utils;
+use atelier_core::{utils, AssetUuid};
 use atelier_schema::{
     data::{asset_change_log_entry, asset_metadata, serialized_asset, AssetSource},
     service::asset_hub,
@@ -77,7 +77,7 @@ impl<'a> AssetHubSnapshotImpl<'a> {
         let mut metadatas = Vec::new();
         for id in params.get_assets()? {
             let id = utils::uuid_from_slice(id.get_id()?)?;
-            let value = ctx.hub.get_metadata(txn, &id)?;
+            let value = ctx.hub.get_metadata(txn, &AssetUuid(id))?;
             if let Some(metadata) = value {
                 metadatas.push(metadata);
             }
@@ -103,7 +103,7 @@ impl<'a> AssetHubSnapshotImpl<'a> {
         let mut metadatas = HashMap::new();
         for id in params.get_assets()? {
             let id = utils::uuid_from_slice(id.get_id()?)?;
-            let value = ctx.hub.get_metadata(txn, &id)?;
+            let value = ctx.hub.get_metadata(txn, &AssetUuid(id))?;
             if let Some(metadata) = value {
                 metadatas.insert(id, metadata);
             }
@@ -118,7 +118,7 @@ impl<'a> AssetHubSnapshotImpl<'a> {
             }
         }
         for id in missing_metadata {
-            let value = ctx.hub.get_metadata(txn, &id)?;
+            let value = ctx.hub.get_metadata(txn, &AssetUuid(id))?;
             if let Some(metadata) = value {
                 metadatas.insert(id, metadata);
             }
@@ -168,7 +168,7 @@ impl<'a> AssetHubSnapshotImpl<'a> {
         let mut scratch_buf = Vec::new();
         for id in params.get_assets()? {
             let id = utils::uuid_from_slice(id.get_id()?)?;
-            let value = ctx.hub.get_metadata(txn, &id)?;
+            let value = ctx.hub.get_metadata(txn, &AssetUuid(id))?;
             if let Some(metadata) = value {
                 let metadata = metadata.get()?;
                 match metadata.get_source()? {
@@ -176,7 +176,7 @@ impl<'a> AssetHubSnapshotImpl<'a> {
                         // TODO run build pipeline
                         if let Some((hash, artifact)) =
                             ctx.file_source
-                                .regenerate_import_artifact(txn, &id, &mut scratch_buf)
+                                .regenerate_import_artifact(txn, &AssetUuid(id), &mut scratch_buf)
                         {
                             let capnp_artifact = build_serialized_asset_message(&artifact);
                             artifacts.push((id, hash, capnp_artifact));
@@ -252,7 +252,7 @@ impl<'a> AssetHubSnapshotImpl<'a> {
         let mut asset_paths = Vec::new();
         for id in params.get_assets()? {
             let asset_uuid = utils::uuid_from_slice(id.get_id()?)?;
-            let path = ctx.file_source.get_asset_path(txn, &asset_uuid);
+            let path = ctx.file_source.get_asset_path(txn, &AssetUuid(asset_uuid));
             if let Some(path) = path {
                 asset_paths.push((id, path));
             }

--- a/daemon/src/source_pair_import.rs
+++ b/daemon/src/source_pair_import.rs
@@ -3,7 +3,7 @@ use crate::error::{Error, Result};
 use crate::file_tracker::FileState;
 use crate::serialized_asset::SerializedAsset;
 use crate::watcher::file_metadata;
-use atelier_core::{utils, AssetUuid};
+use atelier_core::{utils, AssetUuid, AssetTypeId};
 use atelier_importer::{
     AssetMetadata, BoxedImporter, ImporterContext, ImporterContextHandle, SerdeObj,
     SourceMetadata as ImporterSourceMetadata, SOURCEMETADATA_VERSION,
@@ -133,7 +133,7 @@ impl<'a> SourcePairImport<'a> {
                     metadata.importer_options.as_ref(),
                     metadata.importer_state.as_ref(),
                     metadata.importer_version,
-                    metadata.importer_type,
+                    metadata.importer_type.0,
                     scratch_buf,
                 )?);
             }
@@ -191,7 +191,7 @@ impl<'a> SourcePairImport<'a> {
         let mut default_metadata = SourceMetadata {
             version: SOURCEMETADATA_VERSION,
             importer_version: importer.version(),
-            importer_type: importer.uuid(),
+            importer_type: AssetTypeId(importer.uuid()),
             importer_options: importer.default_options(),
             importer_state: importer.default_state(),
             import_hash: None,
@@ -289,7 +289,7 @@ impl<'a> SourcePairImport<'a> {
                             load_deps: deps.into_iter().collect(),
                             instantiate_deps: asset.instantiate_deps,
                             build_pipeline,
-                            import_asset_type: asset_data.uuid(),
+                            import_asset_type: AssetTypeId(asset_data.uuid()),
                         },
                         asset: Some(serialized_asset),
                     }
@@ -308,7 +308,7 @@ impl<'a> SourcePairImport<'a> {
                 version: SOURCEMETADATA_VERSION,
                 import_hash: Some(import_hash),
                 importer_version: importer.version(),
-                importer_type: importer.uuid(),
+                importer_type: AssetTypeId(importer.uuid()),
                 importer_options: options,
                 importer_state: state,
                 assets: imported_assets.iter().map(|m| m.metadata.clone()).collect(),

--- a/importer/src/ron_importer.rs
+++ b/importer/src/ron_importer.rs
@@ -40,7 +40,7 @@ impl Importer for RonImporter {
         state: &mut Self::State,
     ) -> crate::Result<ImporterValue> {
         if state.id.is_none() {
-            state.id = Some(*uuid::Uuid::new_v4().as_bytes());
+            state.id = Some(AssetUuid(*uuid::Uuid::new_v4().as_bytes()));
         }
 
         let de: Box<dyn SerdeImportable> = from_reader(source)?;


### PR DESCRIPTION
The newtypes serialize to a hyphenated UUID format and deserialize from any
UUID format supported by the `uuid` crate. I implemented this by converting to/from `uuid::Uuid` (which should be cheap) to avoid re-implementing the UUID format.

Fixes #34.