### PR TITLE
Make bincode deserialization options consistent

### DIFF
--- a/daemon/src/file_asset_source.rs
+++ b/daemon/src/file_asset_source.rs
@@ -22,6 +22,7 @@ use std::collections::{HashMap, HashSet};
 use std::{path::PathBuf, str, sync::Arc, time::Instant};
 use tokio::{runtime::Runtime};
 use futures_util::lock::Mutex;
+use bincode::config::Options;
 
 pub(crate) struct FileAssetSource {
     hub: Arc<AssetHub>,
@@ -1466,7 +1467,9 @@ where
             if saved_metadata.get_importer_options_type()? == metadata.importer_options.uuid() {
                 let mut deserializer = bincode::Deserializer::from_slice(
                     saved_metadata.get_importer_options()?,
-                    bincode::options(),
+                    bincode::options()
+                        .with_fixint_encoding()
+                        .allow_trailing_bytes(),
                 );
                 let mut deserializer = erased_serde::Deserializer::erase(&mut deserializer);
 
@@ -1477,7 +1480,9 @@ where
             if saved_metadata.get_importer_state_type()? == metadata.importer_state.uuid() {
                 let mut deserializer = bincode::Deserializer::from_slice(
                     saved_metadata.get_importer_state()?,
-                    bincode::options(),
+                    bincode::options()
+                        .with_fixint_encoding()
+                        .allow_trailing_bytes(),
                 );
                 let mut deserializer = erased_serde::Deserializer::erase(&mut deserializer);
                 if let Ok(state) = importer.deserialize_state(&mut deserializer) {


### PR DESCRIPTION
Fixes an issue where asset import state fails to read

I originally tried to use explicit bincode options everywhere but the change ended up not working (looked like alignment issues? https://github.com/aclysma/atelier-assets/commit/aac51d554149412fd7bd13a22d273afe11fd3134

I had another potential fix that I found while bisecting/isolating the problem. It works but probably isn't what we want. https://github.com/aclysma/atelier-assets/commit/464dcf88f7bd7cbeb8b406f6e65424817fc0adb3