### PR TITLE
Add io-util feature to fix compile issue

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -17,7 +17,7 @@ notify = "4.0.0"
 lmdb-rkv = "0.14"
 rayon = { version = "1.3", optional = true }
 log = { version = "0.4", features = ["serde", "std"] }
-tokio = { version = "0.2", features = ["tcp", "fs", "sync", "time", "rt-core", "rt-util", "stream", "rt-threaded"] }
+tokio = { version = "0.2", features = ["tcp", "fs", "sync", "time", "rt-core", "rt-util", "stream", "rt-threaded", "io-util"] }
 tokio-util = { version = "0.3", features = ["compat"] }
 futures = { version = "0.3", default-features = false, features = ["std", "async-await", "executor"] }
 futures-util = { version = "0.3", default-features = false }


### PR DESCRIPTION
Fixes this build error:

```
error[E0599]: no method named `read_to_end` found for struct `tokio::fs::file::File` in the current scope
   --> atelier-assets/daemon/src/source_pair_import.rs:244:11
    |
244 |         f.read_to_end(scratch_buf).await?;
    |           ^^^^^^^^^^^ method not found in `tokio::fs::file::File`
```
