### PR TITLE
Regenerate example meta files so the examples run out of the box

### DIFF
--- a/examples/daemon_with_loader/assets/amethyst.png.meta
+++ b/examples/daemon_with_loader/assets/amethyst.png.meta
@@ -1,20 +1,20 @@
 (
     version: 1,
-    import_hash: Some(11903383758606380406),
+    import_hash: Some(4958181195513810091),
     importer_version: 1,
     importer_type: "720d636b-b79c-42d4-8f46-a2d8e1ada46e",
     importer_options: (),
-    importer_state: (Some("6c5ae1ad-ae30-471b-985b-7d017265f19f")),
+    importer_state: (Some("ec67f02e-1c5c-49b6-8f8d-5cb2649a57e0")),
     assets: [
         (
-            id: "6c5ae1ad-ae30-471b-985b-7d017265f19f",
+            id: "ec67f02e-1c5c-49b6-8f8d-5cb2649a57e0",
             search_tags: [
                 ("file_name", Some("amethyst.png")),
             ],
             build_pipeline: None,
             artifact: Some((
-                hash: 1191698805270338992,
-                id: "6c5ae1ad-ae30-471b-985b-7d017265f19f",
+                id: (14043849890850056775),
+                asset_id: "ec67f02e-1c5c-49b6-8f8d-5cb2649a57e0",
                 build_deps: [],
                 load_deps: [],
                 compression: None,

--- a/examples/handle_integration/assets/amethyst.png.meta
+++ b/examples/handle_integration/assets/amethyst.png.meta
@@ -1,20 +1,20 @@
 (
     version: 1,
-    import_hash: Some(15090209414957017868),
+    import_hash: Some(15817975138823411860),
     importer_version: 1,
     importer_type: "720d636b-b79c-42d4-8f46-a2d8e1ada46e",
     importer_options: (),
-    importer_state: (Some("36605880-e92e-4d87-818f-acc2ab236e9c")),
+    importer_state: (Some("e7c92bd0-d49e-4a8d-9fb9-7fb0286258cd")),
     assets: [
         (
-            id: "36605880-e92e-4d87-818f-acc2ab236e9c",
+            id: "e7c92bd0-d49e-4a8d-9fb9-7fb0286258cd",
             search_tags: [
                 ("file_name", Some("amethyst.png")),
             ],
             build_pipeline: None,
             artifact: Some((
-                hash: 12078420733849445096,
-                id: "36605880-e92e-4d87-818f-acc2ab236e9c",
+                id: (9233509197430240990),
+                asset_id: "e7c92bd0-d49e-4a8d-9fb9-7fb0286258cd",
                 build_deps: [],
                 load_deps: [],
                 compression: None,

--- a/examples/handle_integration/assets/custom_asset.ron.meta
+++ b/examples/handle_integration/assets/custom_asset.ron.meta
@@ -1,22 +1,22 @@
 (
     version: 1,
-    import_hash: Some(11943023854699880),
+    import_hash: Some(6730457197842789632),
     importer_version: 1,
     importer_type: "162ede20-6fdd-44c1-8387-8f93983c067c",
     importer_options: (),
     importer_state: (
-        id: Some("0977fd59-e52d-4910-85e0-d61ae8affa8c"),
+        id: Some("a1f0e0d2-2d2a-4a24-bb76-8874f4cf953d"),
     ),
     assets: [
         (
-            id: "0977fd59-e52d-4910-85e0-d61ae8affa8c",
+            id: "a1f0e0d2-2d2a-4a24-bb76-8874f4cf953d",
             search_tags: [
                 ("file_name", Some("custom_asset.ron")),
             ],
             build_pipeline: None,
             artifact: Some((
-                hash: 10868599799857052654,
-                id: "0977fd59-e52d-4910-85e0-d61ae8affa8c",
+                id: (18219351567070105851),
+                asset_id: "a1f0e0d2-2d2a-4a24-bb76-8874f4cf953d",
                 build_deps: [
                     Uuid("36605880-e92e-4d87-818f-acc2ab236e9c"),
                     Path("amethyst.png"),


### PR DESCRIPTION
It appears that the meta format has changed slightly since these files were created. This just updates them so that the examples run without fiddling.