### PR TITLE
Add rt-threaded feature to tokio dependency

### DIFF
--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 crossbeam-channel = "0.5.0"
 atelier-core = { path = "../core", version = "0.1.0", features = ["serde-1"] }
 atelier-schema = { path = "../schema", version = "0.1.0", optional = true }
-tokio = { version = "0.2", features = ["tcp", "sync", "rt-core", "rt-util", "stream"], optional = true }
+tokio = { version = "0.2", features = ["tcp", "sync", "rt-core", "rt-util", "rt-threaded", "stream"], optional = true }
 tokio-util = { version = "0.3", features = ["compat"], optional = true }
 futures-util = { version = "0.3.9", default-features = false, features = ["io"], optional = true }
 futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Atelier uses tokio::Builder::threaded_scheduler, which is gated by the rt-threaded feature but that feature wasn't being specified (I guess it was being added implicitly by some other dependency). This adds the missing feature.