### PR TITLE
Rustfmt.toml

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,13 +1,12 @@
+use std::{cell::RefCell, path::PathBuf, rc::Rc, time::Instant};
+
+use async_trait::async_trait;
 use atelier_schema::{
     data, pack,
     service::asset_hub::{self, snapshot::Client as Snapshot},
 };
-use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
-
 use capnp::message::ReaderOptions;
-
-use async_trait::async_trait;
-use std::{cell::RefCell, path::PathBuf, rc::Rc, time::Instant};
+use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
 
 pub mod shell;
 use shell::Autocomplete;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,4 @@
-use atelier_cli::shell::Shell;
-use atelier_cli::*;
+use atelier_cli::{shell::Shell, *};
 use tokio::runtime::Runtime;
 
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/cli/src/shell.rs
+++ b/cli/src/shell.rs
@@ -1,4 +1,5 @@
-use crate::DynResult;
+use std::{collections::HashMap, io::Write, pin::Pin};
+
 use async_trait::async_trait;
 use crossterm::{
     cursor::{MoveLeft, MoveToColumn, MoveUp},
@@ -7,12 +8,13 @@ use crossterm::{
     style::{Color, Print, ResetColor, SetBackgroundColor, SetForegroundColor},
     terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
 };
-use futures::select;
 use futures::{
     future::{pending, FusedFuture, FutureExt},
+    select,
     stream::StreamExt,
 };
-use std::{collections::HashMap, io::Write, pin::Pin};
+
+use crate::DynResult;
 
 #[async_trait(?Send)]
 pub trait Command<C> {

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -1,15 +1,16 @@
 // this is just a test crate at the moment
-use atelier_schema::service::asset_hub;
-use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
-
-use capnp::message::ReaderOptions;
-
 use std::{
-    sync::atomic::{AtomicUsize, Ordering},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     thread,
     time::Instant,
 };
+
+use atelier_schema::service::asset_hub;
+use capnp::message::ReaderOptions;
+use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use tokio::runtime::Runtime;
 
 pub fn main() {

--- a/core/src/importer_context.rs
+++ b/core/src/importer_context.rs
@@ -1,5 +1,6 @@
-use crate::{AssetRef, AssetUuid};
 use futures_core::future::BoxFuture;
+
+use crate::{AssetRef, AssetUuid};
 
 pub trait ImporterContextHandle: Send + Sync {
     fn scope<'a>(&'a self, fut: BoxFuture<'a, ()>) -> BoxFuture<'a, ()>;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,14 +1,14 @@
+use std::fmt;
+#[cfg(feature = "serde-1")]
+use std::str::FromStr;
+
 #[cfg(feature = "serde-1")]
 use serde::{
     de::{self, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-#[cfg(feature = "serde-1")]
-use std::str::FromStr;
 pub use uuid;
 use uuid::Uuid;
-
-use std::fmt;
 
 pub mod importer_context;
 pub mod utils;

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,9 +1,10 @@
-use crate::{AssetTypeId, AssetUuid};
 use std::{
     ffi::OsStr,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
 };
+
+use crate::{AssetTypeId, AssetUuid};
 
 pub fn make_array<A, T>(slice: &[T]) -> A
 where

--- a/daemon/src/artifact_cache.rs
+++ b/daemon/src/artifact_cache.rs
@@ -53,9 +53,11 @@ impl ArtifactCache {
         )
         .expect("lmdb: failed to put path ref");
     }
+
     pub async fn ro_txn(&self) -> Result<RoTransaction<'_>> {
         self.db.ro_txn().await
     }
+
     pub async fn rw_txn(&self) -> Result<RwTransaction<'_>> {
         self.db.rw_txn().await
     }

--- a/daemon/src/artifact_cache.rs
+++ b/daemon/src/artifact_cache.rs
@@ -1,8 +1,12 @@
-use crate::capnp_db::{DBTransaction, Environment, MessageReader, RoTransaction, RwTransaction};
-use crate::error::Result;
+use std::sync::Arc;
+
 use atelier_importer::SerializedAsset;
 use atelier_schema::{build_artifact_metadata, data::artifact};
-use std::sync::Arc;
+
+use crate::{
+    capnp_db::{DBTransaction, Environment, MessageReader, RoTransaction, RwTransaction},
+    error::Result,
+};
 
 pub struct ArtifactCache {
     db: Arc<Environment>,

--- a/daemon/src/asset_hub.rs
+++ b/daemon/src/asset_hub.rs
@@ -1,5 +1,13 @@
-use crate::capnp_db::{CapnpCursor, DBTransaction, Environment, MessageReader, RwTransaction};
-use crate::error::{Error, Result};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    hash::{Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
+
 use async_channel::Sender;
 use atelier_core::{utils, AssetRef, AssetUuid};
 use atelier_importer::AssetMetadata;
@@ -11,14 +19,10 @@ use atelier_schema::{
     },
     parse_db_asset_ref,
 };
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    hash::{Hash, Hasher},
-    path::{Path, PathBuf},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc, Mutex,
-    },
+
+use crate::{
+    capnp_db::{CapnpCursor, DBTransaction, Environment, MessageReader, RwTransaction},
+    error::{Error, Result},
 };
 
 pub type ListenerID = u64;

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -136,6 +136,7 @@ impl AssetHubSnapshotImpl {
         }
         Ok(())
     }
+
     fn get_asset_metadata_with_dependencies(
         &mut self,
         params: asset_hub::snapshot::GetAssetMetadataWithDependenciesParams,
@@ -181,6 +182,7 @@ impl AssetHubSnapshotImpl {
         }
         Ok(())
     }
+
     fn get_all_asset_metadata(
         &mut self,
         _params: asset_hub::snapshot::GetAllAssetMetadataParams,
@@ -204,6 +206,7 @@ impl AssetHubSnapshotImpl {
         }
         Ok(())
     }
+
     async fn get_import_artifacts(
         snapshot: Arc<SnapshotTxn>,
         params: asset_hub::snapshot::GetImportArtifactsParams,
@@ -285,6 +288,7 @@ impl AssetHubSnapshotImpl {
         }
         Ok(())
     }
+
     fn get_latest_asset_change(
         &mut self,
         _params: asset_hub::snapshot::GetLatestAssetChangeParams,
@@ -296,6 +300,7 @@ impl AssetHubSnapshotImpl {
         results.get().set_num(change_num);
         Ok(())
     }
+
     fn get_asset_changes(
         &mut self,
         params: asset_hub::snapshot::GetAssetChangesParams,
@@ -326,6 +331,7 @@ impl AssetHubSnapshotImpl {
         }
         Ok(())
     }
+
     fn get_path_for_assets(
         &mut self,
         params: asset_hub::snapshot::GetPathForAssetsParams,
@@ -368,6 +374,7 @@ impl AssetHubSnapshotImpl {
         }
         Ok(())
     }
+
     fn get_assets_for_paths(
         &mut self,
         params: asset_hub::snapshot::GetAssetsForPathsParams,
@@ -500,6 +507,7 @@ impl asset_hub::Server for AssetHubImpl {
         log::trace!("asset_hub::Server::register_listener");
         Promise::ok(pry!(AssetHubImpl::register_listener(self, params, results)))
     }
+
     fn get_snapshot(
         &mut self,
         params: asset_hub::GetSnapshotParams,
@@ -621,6 +629,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             self, params, results
         )))
     }
+
     fn get_asset_metadata_with_dependencies(
         &mut self,
         params: asset_hub::snapshot::GetAssetMetadataWithDependenciesParams,
@@ -631,6 +640,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             AssetHubSnapshotImpl::get_asset_metadata_with_dependencies(self, params, results)
         ))
     }
+
     fn get_all_asset_metadata(
         &mut self,
         params: asset_hub::snapshot::GetAllAssetMetadataParams,
@@ -641,6 +651,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             self, params, results
         )))
     }
+
     fn get_import_artifacts(
         &mut self,
         params: asset_hub::snapshot::GetImportArtifactsParams,
@@ -650,6 +661,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
         let fut = AssetHubSnapshotImpl::get_import_artifacts(self.txn.clone(), params, results);
         Promise::from_future(async { fut.await.map_err(|e| e.into()) })
     }
+
     fn get_latest_asset_change(
         &mut self,
         params: asset_hub::snapshot::GetLatestAssetChangeParams,
@@ -660,6 +672,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             self, params, results
         )))
     }
+
     fn get_asset_changes(
         &mut self,
         params: asset_hub::snapshot::GetAssetChangesParams,
@@ -670,6 +683,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             self, params, results
         )))
     }
+
     fn get_path_for_assets(
         &mut self,
         params: asset_hub::snapshot::GetPathForAssetsParams,
@@ -680,6 +694,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             self, params, results
         )))
     }
+
     fn get_assets_for_paths(
         &mut self,
         params: asset_hub::snapshot::GetAssetsForPathsParams,
@@ -690,6 +705,7 @@ impl asset_hub::snapshot::Server for AssetHubSnapshotImpl {
             self, params, results
         )))
     }
+
     fn update_asset(
         &mut self,
         params: asset_hub::snapshot::UpdateAssetParams,

--- a/daemon/src/asset_hub_service.rs
+++ b/daemon/src/asset_hub_service.rs
@@ -1,11 +1,10 @@
-use crate::{
-    artifact_cache::ArtifactCache,
-    asset_hub::{AssetBatchEvent, AssetHub},
-    capnp_db::{CapnpCursor as _, Environment, RoTransaction},
-    error::Error,
-    file_asset_source::FileAssetSource,
-    file_tracker::FileTracker,
+use std::{
+    collections::{HashMap, HashSet},
+    path,
+    rc::Rc,
+    sync::Arc,
 };
+
 use atelier_core::utils::{self, canonicalize_path};
 use atelier_importer::SerializedAsset;
 use atelier_schema::{
@@ -19,14 +18,15 @@ use atelier_schema::{
     service::asset_hub,
 };
 use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
+use futures::{AsyncReadExt, TryFutureExt};
 
-use futures::AsyncReadExt;
-use futures::TryFutureExt;
-use std::{
-    collections::{HashMap, HashSet},
-    path,
-    rc::Rc,
-    sync::Arc,
+use crate::{
+    artifact_cache::ArtifactCache,
+    asset_hub::{AssetBatchEvent, AssetHub},
+    capnp_db::{CapnpCursor as _, Environment, RoTransaction},
+    error::Error,
+    file_asset_source::FileAssetSource,
+    file_tracker::FileTracker,
 };
 
 // crate::Error has `impl From<crate::Error> for capnp::Error`

--- a/daemon/src/capnp_db.rs
+++ b/daemon/src/capnp_db.rs
@@ -54,6 +54,7 @@ impl<'txn> CapnpCursor<'txn> for lmdb::RoCursor<'txn> {
             _marker: std::marker::PhantomData,
         }
     }
+
     fn capnp_iter_from<'cursor, K>(mut self, key: &K) -> Iter<'cursor, 'txn>
     where
         K: AsRef<[u8]>,
@@ -71,6 +72,7 @@ impl<'cursor, 'txn> Iterator for Iter<'cursor, 'txn> {
         &'txn [u8],
         StdResult<capnp::message::Reader<capnp::serialize::SliceSegments<'txn>>, capnp::Error>,
     );
+
     fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next() {
             Some(Ok((key_bytes, value_bytes))) => {
@@ -187,6 +189,7 @@ impl<'a> RwTransaction<'a> {
         self.dirty = true;
         Ok(())
     }
+
     pub fn put_bytes<K, V>(&mut self, db: lmdb::Database, key: &K, value: &V) -> Result<()>
     where
         K: AsRef<[u8]>,
@@ -196,6 +199,7 @@ impl<'a> RwTransaction<'a> {
         self.dirty = true;
         Ok(())
     }
+
     pub fn delete<K>(&mut self, db: lmdb::Database, key: &K) -> Result<bool>
     where
         K: AsRef<[u8]>,

--- a/daemon/src/daemon.rs
+++ b/daemon/src/daemon.rs
@@ -8,17 +8,17 @@ use std::{
     thread::JoinHandle,
 };
 
+use asset_hub::AssetHub;
+use asset_hub_service::AssetHubService;
 use atelier_importer::{BoxedImporter, ImporterContext};
 use atelier_schema::data;
+use file_asset_source::FileAssetSource;
 use tokio::sync::oneshot::{self, Receiver, Sender};
 
 use crate::{
     artifact_cache::ArtifactCache, asset_hub, asset_hub_service, capnp_db::Environment,
     error::Result, file_asset_source, file_tracker::FileTracker,
 };
-use asset_hub::AssetHub;
-use asset_hub_service::AssetHubService;
-use file_asset_source::FileAssetSource;
 
 #[derive(Default)]
 pub struct ImporterMap(HashMap<String, Box<dyn BoxedImporter>>);

--- a/daemon/src/file_asset_source.rs
+++ b/daemon/src/file_asset_source.rs
@@ -1552,6 +1552,7 @@ where
         }
         Ok(())
     }
+
     fn get_cached_metadata(&self, path: &Path) -> Result<Option<ImportResultMetadata>> {
         let saved_metadata = self.file_asset_source.get_metadata(self.txn, path);
         if let Some(saved_metadata) = saved_metadata {

--- a/daemon/src/file_tracker.rs
+++ b/daemon/src/file_tracker.rs
@@ -107,11 +107,13 @@ impl ListenersList {
             listeners: Vec::new(),
         }
     }
+
     fn register(&mut self, new_listener: Option<UnboundedSender<FileTrackerEvent>>) {
         if let Some(new_listener) = new_listener {
             self.listeners.push(new_listener);
         }
     }
+
     fn send_event(&mut self, event: FileTrackerEvent) {
         self.listeners.retain(|listener| {
             match listener.unbounded_send(event) {

--- a/daemon/src/scope.rs
+++ b/daemon/src/scope.rs
@@ -1,11 +1,15 @@
 #![allow(clippy::needless_lifetimes)]
-use futures::future::FutureExt;
-use futures::future::{BoxFuture, Future};
-use futures::stream::{FuturesUnordered, Stream};
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{
+    future::{BoxFuture, Future, FutureExt},
+    stream::{FuturesUnordered, Stream},
+};
 use pin_project::{pin_project, pinned_drop};
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use tokio::task::JoinHandle;
 
 /// A scope to allow controlled spawning of non 'static

--- a/daemon/src/serialized_asset.rs
+++ b/daemon/src/serialized_asset.rs
@@ -1,6 +1,7 @@
-use crate::Result;
 use atelier_core::{ArtifactId, AssetRef, AssetTypeId, AssetUuid, CompressionType};
 use atelier_importer::{ArtifactMetadata, SerdeObj, SerializedAsset};
+
+use crate::Result;
 
 pub fn create(
     hash: u64,

--- a/daemon/src/source_pair_import.rs
+++ b/daemon/src/source_pair_import.rs
@@ -140,11 +140,13 @@ impl ImporterContextHandleSet {
             handle.resolve_ref(asset_ref, id);
         }
     }
+
     pub fn begin_serialize_asset(&mut self, id: AssetUuid) {
         for handle in self.0.iter_mut() {
             handle.begin_serialize_asset(id);
         }
     }
+
     pub fn end_serialize_asset(&mut self, id: AssetUuid) -> HashSet<AssetRef> {
         let mut deps = HashSet::new();
         for handle in self.0.iter_mut() {
@@ -163,15 +165,19 @@ impl<'a> SourcePairImport<'a> {
             ..Default::default()
         }
     }
+
     pub fn source_metadata(&self) -> Option<&SourceMetadata> {
         self.source_metadata.as_ref()
     }
+
     pub fn result_metadata(&self) -> Option<&ImportResultMetadata> {
         self.result_metadata.as_ref()
     }
+
     pub fn set_source_hash(&mut self, source_hash: u64) {
         self.source_hash = Some(source_hash);
     }
+
     pub fn set_meta_hash(&mut self, meta_hash: u64) {
         self.meta_hash = Some(meta_hash);
     }

--- a/daemon/src/watcher.rs
+++ b/daemon/src/watcher.rs
@@ -110,6 +110,7 @@ impl DirWatcher {
             .map_err(|_| Error::SendError)?;
         result
     }
+
     fn scan_directory_recurse<F>(&mut self, dir: &Path, evt_create: &F) -> Result<()>
     where
         F: Fn(PathBuf) -> DebouncedEvent,

--- a/examples/daemon_with_loader/src/game.rs
+++ b/examples/daemon_with_loader/src/game.rs
@@ -1,4 +1,9 @@
-use crate::image::Image;
+use std::{
+    cell::{Ref, RefCell},
+    collections::HashMap,
+    error::Error,
+};
+
 use atelier_assets::{
     core::type_uuid::TypeUuid,
     loader::{
@@ -10,11 +15,8 @@ use atelier_assets::{
         AssetTypeId, RpcIO,
     },
 };
-use std::{
-    cell::{Ref, RefCell},
-    collections::HashMap,
-    error::Error,
-};
+
+use crate::image::Image;
 
 #[allow(dead_code)]
 struct AssetState<A> {

--- a/examples/daemon_with_loader/src/game.rs
+++ b/examples/daemon_with_loader/src/game.rs
@@ -36,6 +36,7 @@ impl<A> Storage<A> {
             indirection_table,
         }
     }
+
     pub fn get_asset(&self, handle: LoadHandle) -> Option<Ref<'_, A>> {
         let handle = if handle.is_indirect() {
             self.indirection_table.resolve(handle)?
@@ -78,6 +79,7 @@ impl<A: for<'a> serde::Deserialize<'a>> AssetStorage for Storage<A> {
         load_op.complete();
         Ok(())
     }
+
     fn commit_asset_version(
         &self,
         _asset_type: &AssetTypeId,
@@ -98,6 +100,7 @@ impl<A: for<'a> serde::Deserialize<'a>> AssetStorage for Storage<A> {
         );
         log::info!("Commit {:?}", load_handle);
     }
+
     fn free(&self, _asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32) {
         let mut uncommitted = self.uncommitted.borrow_mut();
         if let Some(asset) = uncommitted.get(&load_handle) {
@@ -141,6 +144,7 @@ impl AssetStorage for Game {
                 version,
             )
     }
+
     fn commit_asset_version(
         &self,
         asset_type: &AssetTypeId,
@@ -152,6 +156,7 @@ impl AssetStorage for Game {
             .expect("unknown asset type")
             .commit_asset_version(asset_type, load_handle, version)
     }
+
     fn free(&self, asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32) {
         self.storage
             .get(asset_type_id)

--- a/examples/daemon_with_loader/src/image.rs
+++ b/examples/daemon_with_loader/src/image.rs
@@ -22,19 +22,19 @@ pub struct SimpleState(Option<AssetUuid>);
 #[uuid = "720d636b-b79c-42d4-8f46-a2d8e1ada46e"]
 pub struct ImageImporter;
 impl AsyncImporter for ImageImporter {
+    type Options = ();
+    type State = SimpleState;
+
     fn version_static() -> u32
     where
         Self: Sized,
     {
         1
     }
+
     fn version(&self) -> u32 {
         Self::version_static()
     }
-
-    type Options = ();
-
-    type State = SimpleState;
 
     /// Reads the given bytes and produces assets.
     fn import<'a>(

--- a/examples/daemon_with_loader/src/main.rs
+++ b/examples/daemon_with_loader/src/main.rs
@@ -1,8 +1,9 @@
 mod game;
 mod image;
+use std::path::PathBuf;
+
 use atelier_assets::daemon::{init_logging, AssetDaemon};
 pub use game::Storage;
-use std::path::PathBuf;
 
 fn main() {
     init_logging().expect("failed to init logging");

--- a/examples/handle_integration/src/custom_asset.rs
+++ b/examples/handle_integration/src/custom_asset.rs
@@ -1,5 +1,5 @@
-use atelier_assets::core::{type_uuid, type_uuid::TypeUuid};
 use atelier_assets::{
+    core::{type_uuid, type_uuid::TypeUuid},
     importer::{self as atelier_importer, typetag, SerdeImportable},
     loader::handle::Handle,
 };

--- a/examples/handle_integration/src/game.rs
+++ b/examples/handle_integration/src/game.rs
@@ -1,11 +1,13 @@
-use crate::{custom_asset::BigPerf, image::Image, storage::GenericAssetStorage};
+use std::sync::Arc;
+
 use atelier_assets::loader::{
     crossbeam_channel::{unbounded, Receiver},
     handle::{self, AssetHandle, Handle, RefOp, WeakHandle},
     storage::{DefaultIndirectionResolver, IndirectIdentifier, LoadStatus},
     Loader, RpcIO,
 };
-use std::sync::Arc;
+
+use crate::{custom_asset::BigPerf, image::Image, storage::GenericAssetStorage};
 
 struct Game {
     storage: GenericAssetStorage,

--- a/examples/handle_integration/src/main.rs
+++ b/examples/handle_integration/src/main.rs
@@ -3,8 +3,9 @@ mod game;
 mod image;
 mod storage;
 
-use atelier_assets::daemon::{init_logging, AssetDaemon};
 use std::path::PathBuf;
+
+use atelier_assets::daemon::{init_logging, AssetDaemon};
 
 fn main() {
     init_logging().expect("failed to init logging");

--- a/examples/handle_integration/src/storage.rs
+++ b/examples/handle_integration/src/storage.rs
@@ -56,6 +56,7 @@ impl<A: TypeUuid> Storage<A> {
             indirection_table,
         }
     }
+
     fn get<T: AssetHandle>(&self, handle: &T) -> Option<&A> {
         let handle = if handle.load_handle().is_indirect() {
             self.indirection_table.resolve(handle.load_handle())?
@@ -64,6 +65,7 @@ impl<A: TypeUuid> Storage<A> {
         };
         self.assets.get(&handle).map(|a| &a.asset)
     }
+
     fn get_version<T: AssetHandle>(&self, handle: &T) -> Option<u32> {
         let handle = if handle.load_handle().is_indirect() {
             self.indirection_table.resolve(handle.load_handle())?
@@ -72,6 +74,7 @@ impl<A: TypeUuid> Storage<A> {
         };
         self.assets.get(&handle).map(|a| a.version)
     }
+
     fn get_asset_with_version<T: AssetHandle>(&self, handle: &T) -> Option<(&A, u32)> {
         let handle = if handle.load_handle().is_indirect() {
             self.indirection_table.resolve(handle.load_handle())?
@@ -100,6 +103,7 @@ impl<A: TypeUuid + for<'a> serde::Deserialize<'a> + 'static> TypedAssetStorage<A
             )
         }
     }
+
     fn get_version<T: AssetHandle>(&self, handle: &T) -> Option<u32> {
         self.storage
             .borrow()
@@ -111,6 +115,7 @@ impl<A: TypeUuid + for<'a> serde::Deserialize<'a> + 'static> TypedAssetStorage<A
             .expect("failed to downcast")
             .get_version(handle)
     }
+
     fn get_asset_with_version<T: AssetHandle>(&self, handle: &T) -> Option<(&A, u32)> {
         // This transmute can probably be unsound, but I don't have the energy to fix it right now
         unsafe {
@@ -146,6 +151,7 @@ impl<A: for<'a> serde::Deserialize<'a> + 'static + TypeUuid> TypedStorage for St
     fn any(&self) -> &dyn Any {
         self
     }
+
     fn update_asset(
         &mut self,
         loader_info: &dyn LoaderInfoProvider,
@@ -169,6 +175,7 @@ impl<A: for<'a> serde::Deserialize<'a> + 'static + TypeUuid> TypedStorage for St
         load_op.complete();
         Ok(())
     }
+
     fn commit_asset_version(&mut self, load_handle: LoadHandle, _version: u32) {
         // The commit step is done after an asset load has completed.
         // It exists to avoid frames where an asset that was loaded is unloaded, which
@@ -182,6 +189,7 @@ impl<A: for<'a> serde::Deserialize<'a> + 'static + TypeUuid> TypedStorage for St
         );
         log::info!("Commit {:?}", load_handle);
     }
+
     fn free(&mut self, load_handle: LoadHandle, version: u32) {
         if let Some(asset) = self.uncommitted.get(&load_handle) {
             if asset.version == version {
@@ -214,6 +222,7 @@ impl AssetStorage for GenericAssetStorage {
             .expect("unknown asset type")
             .update_asset(loader_info, data, load_handle, load_op, version)
     }
+
     fn commit_asset_version(
         &self,
         asset_type: &AssetTypeId,
@@ -226,6 +235,7 @@ impl AssetStorage for GenericAssetStorage {
             .expect("unknown asset type")
             .commit_asset_version(load_handle, version)
     }
+
     fn free(&self, asset_type_id: &AssetTypeId, load_handle: LoadHandle, version: u32) {
         self.storage
             .borrow_mut()

--- a/examples/handle_integration/src/storage.rs
+++ b/examples/handle_integration/src/storage.rs
@@ -1,11 +1,14 @@
-use atelier_assets::core::type_uuid::TypeUuid;
-use atelier_assets::loader::{
-    crossbeam_channel::Sender,
-    handle::{AssetHandle, RefOp, TypedAssetStorage},
-    storage::{AssetLoadOp, AssetStorage, IndirectionTable, LoadHandle, LoaderInfoProvider},
-    AssetTypeId,
-};
 use std::{any::Any, cell::RefCell, collections::HashMap, error::Error, sync::Arc};
+
+use atelier_assets::{
+    core::type_uuid::TypeUuid,
+    loader::{
+        crossbeam_channel::Sender,
+        handle::{AssetHandle, RefOp, TypedAssetStorage},
+        storage::{AssetLoadOp, AssetStorage, IndirectionTable, LoadHandle, LoaderInfoProvider},
+        AssetTypeId,
+    },
+};
 
 pub struct GenericAssetStorage {
     storage: RefCell<HashMap<AssetTypeId, Box<dyn TypedStorage>>>,

--- a/importer/src/boxed_importer.rs
+++ b/importer/src/boxed_importer.rs
@@ -1,9 +1,9 @@
-use crate::{error::Result, AsyncImporter, ExportAsset, ImportOp, ImporterValue, SerdeObj};
 use atelier_core::TypeUuidDynamic;
 use erased_serde::Deserializer;
-use futures::future::BoxFuture;
-use futures::{AsyncRead, AsyncWrite};
+use futures::{future::BoxFuture, AsyncRead, AsyncWrite};
 use serde::{Deserialize, Serialize};
+
+use crate::{error::Result, AsyncImporter, ExportAsset, ImportOp, ImporterValue, SerdeObj};
 
 /// Version of the SourceMetadata struct.
 /// Used for forward compatibility to enable changing the .meta file format

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -42,9 +42,11 @@ impl ImportOp {
     pub fn error<T: Into<Box<dyn std::error::Error + Send + 'static>>>(&mut self, err: T) {
         self.errors.push(err.into());
     }
+
     pub fn warn<T: Into<Box<dyn std::error::Error + Send + 'static>>>(&mut self, err: T) {
         self.warnings.push(err.into());
     }
+
     pub fn new_asset_uuid(&self) -> AssetUuid {
         AssetUuid(*uuid::Uuid::new_v4().as_bytes())
     }

--- a/importer/src/lib.rs
+++ b/importer/src/lib.rs
@@ -5,33 +5,31 @@ mod serialized_asset;
 
 #[cfg(feature = "serde_importers")]
 mod ron_importer;
+use std::io::{Read, Write};
+
+pub use atelier_core::{
+    importer_context::{ImporterContext, ImporterContextHandle},
+    ArtifactMetadata, AssetMetadata,
+};
+use atelier_core::{AssetRef, AssetUuid};
+use futures::{future::BoxFuture, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+pub use serde;
+use serde::Serialize;
+#[cfg(feature = "serde_importers")]
+pub use serde_importable_derive::*;
+
+pub use self::error::{Error, Result};
 #[cfg(feature = "serde_importers")]
 pub use crate::ron_importer::{RonImporter, RonImporterOptions, RonImporterState};
 #[doc(hidden)]
 #[cfg(feature = "serde_importers")]
 pub use crate::serde_obj::typetag;
 #[cfg(feature = "serde_importers")]
-pub use serde_importable_derive::*;
-
-pub use serde;
-
-use atelier_core::{AssetRef, AssetUuid};
-use futures::{future::BoxFuture, AsyncReadExt, AsyncWriteExt};
-use futures::{AsyncRead, AsyncWrite};
-use serde::Serialize;
-use std::io::{Read, Write};
-
-pub use self::error::{Error, Result};
-#[cfg(feature = "serde_importers")]
 pub use crate::serde_obj::SerdeImportable;
 pub use crate::{
     boxed_importer::{BoxedImporter, SourceMetadata, SOURCEMETADATA_VERSION},
     serde_obj::{IntoSerdeObj, SerdeObj},
     serialized_asset::SerializedAsset,
-};
-pub use atelier_core::{
-    importer_context::{ImporterContext, ImporterContextHandle},
-    ArtifactMetadata, AssetMetadata,
 };
 
 #[derive(Default)]

--- a/importer/src/ron_importer.rs
+++ b/importer/src/ron_importer.rs
@@ -1,8 +1,10 @@
-use crate::{ImportOp, ImportedAsset, Importer, ImporterValue, Result, SerdeImportable};
+use std::io::Read;
+
 use atelier_core::{type_uuid, type_uuid::TypeUuid, AssetUuid};
 use ron::de::from_reader;
 use serde::{Deserialize, Serialize};
-use std::io::Read;
+
+use crate::{ImportOp, ImportedAsset, Importer, ImporterValue, Result, SerdeImportable};
 
 #[derive(Default, Deserialize, Serialize, TypeUuid, Clone, Copy)]
 #[uuid = "f3cd048a-2c98-4e4b-95a2-d7c0ee6f7beb"]
@@ -58,10 +60,11 @@ impl Importer for RonImporter {
 }
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use crate as atelier_importer;
     use crate::*;
-    use std::collections::HashMap;
 
     #[derive(Serialize, Deserialize, TypeUuid, SerdeImportable, PartialEq, Eq)]
     #[uuid = "36fb2083-7195-4583-8af9-0965f10ae60d"]

--- a/importer/src/serde_obj.rs
+++ b/importer/src/serde_obj.rs
@@ -1,6 +1,7 @@
+use std::any::Any;
+
 use atelier_core::TypeUuidDynamic;
 use erased_serde::*;
-use std::any::Any;
 
 /// A trait for serializing any struct with a TypeUuid
 pub trait SerdeObj: Any + Serialize + TypeUuidDynamic + Send {
@@ -38,7 +39,6 @@ pub trait SerdeImportable: SerdeObj + IntoSerdeObj {}
 #[cfg(feature = "serde_importers")]
 #[doc(hidden)]
 pub use serde_importable_derive::*;
-
 #[doc(hidden)]
 #[cfg(feature = "serde_importers")]
 pub use typetag;

--- a/importer/src/serde_obj.rs
+++ b/importer/src/serde_obj.rs
@@ -12,6 +12,7 @@ impl<T: Serialize + TypeUuidDynamic + Send + 'static> SerdeObj for T {
     fn any(&self) -> &dyn Any {
         self
     }
+
     fn any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/loader/src/handle.rs
+++ b/loader/src/handle.rs
@@ -1,13 +1,3 @@
-use crate::{
-    storage::{LoadStatus, LoaderInfoProvider},
-    AssetRef, AssetUuid, LoadHandle, Loader,
-};
-use crossbeam_channel::{unbounded, Receiver, Sender};
-use futures_core::future::{BoxFuture, Future};
-use serde::{
-    de::{self, Deserialize, Visitor},
-    ser::{self, Serialize, Serializer},
-};
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -17,6 +7,18 @@ use std::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex, RwLock,
     },
+};
+
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use futures_core::future::{BoxFuture, Future};
+use serde::{
+    de::{self, Deserialize, Visitor},
+    ser::{self, Serialize, Serializer},
+};
+
+use crate::{
+    storage::{LoadStatus, LoaderInfoProvider},
+    AssetRef, AssetUuid, LoadHandle, Loader,
 };
 
 /// Operations on an asset reference.
@@ -542,10 +544,12 @@ impl<'de> Visitor<'de> for AssetRefVisitor {
                     Ok(AssetRef::Path(path))
                 }
             }
-            Err(err) => Err(E::custom(format!(
-                "failed to parse Handle string: {:?}",
-                err
-            ))),
+            Err(err) => {
+                Err(E::custom(format!(
+                    "failed to parse Handle string: {:?}",
+                    err
+                )))
+            }
         }
     }
 

--- a/loader/src/handle.rs
+++ b/loader/src/handle.rs
@@ -277,6 +277,7 @@ impl SerdeContext {
     pub fn with_active<R>(f: impl FnOnce(&dyn LoaderInfoProvider, &Sender<RefOp>) -> R) -> R {
         LOADER.with(|l| REFOP_SENDER.with(|r| f(*l, &r)))
     }
+
     pub async fn with<F>(loader: &dyn LoaderInfoProvider, sender: Sender<RefOp>, f: F) -> F::Output
     where
         F: Future,

--- a/loader/src/io.rs
+++ b/loader/src/io.rs
@@ -25,9 +25,11 @@ impl DataRequest {
     pub fn asset_id(&self) -> AssetUuid {
         self.asset_id
     }
+
     pub fn artifact_id(&self) -> ArtifactId {
         self.artifact_id
     }
+
     pub fn error<T: std::error::Error + Send + 'static>(mut self, err: T) {
         if let Some(request_data) = self.request_data.take() {
             let _ = self
@@ -35,6 +37,7 @@ impl DataRequest {
                 .send((Err(Box::new(err)), request_data.0, request_data.1));
         }
     }
+
     pub fn complete(mut self, data: Vec<u8>) {
         if let Some(request_data) = self.request_data.take() {
             let _ = self.tx.send((Ok(data), request_data.0, request_data.1));
@@ -67,11 +70,13 @@ impl ResolveRequest {
     pub fn identifier(&self) -> &IndirectIdentifier {
         self.id.as_ref().map(|v| &v.0).unwrap()
     }
+
     pub fn error<T: std::error::Error + Send + 'static>(mut self, err: T) {
         if let Some(id) = self.id.take() {
             let _ = self.tx.send((Err(Box::new(err)), id.0, id.1));
         }
     }
+
     pub fn complete(mut self, data: Vec<(PathBuf, Vec<AssetMetadata>)>) {
         if let Some(id) = self.id.take() {
             let _ = self.tx.send((Ok(data), id.0, id.1));
@@ -107,11 +112,13 @@ impl MetadataRequest {
     pub fn requested_assets(&self) -> impl Iterator<Item = &AssetUuid> {
         self.requests.as_ref().unwrap().keys()
     }
+
     pub fn error<T: std::error::Error + Send + 'static>(mut self, err: T) {
         if let Some(requests) = self.requests.take() {
             let _ = self.tx.send((Err(Box::new(err)), requests));
         }
     }
+
     pub fn complete(mut self, metadata: Vec<ArtifactMetadata>) {
         if let Some(requests) = self.requests.take() {
             let _ = self.tx.send((Ok(metadata), requests));

--- a/loader/src/loader.rs
+++ b/loader/src/loader.rs
@@ -212,6 +212,7 @@ impl LoaderState {
         });
         handle
     }
+
     fn add_refs(&self, id: AssetUuid, num_refs: usize) -> LoadHandle {
         let handle = self.get_or_insert(id);
         self.load_states
@@ -219,6 +220,7 @@ impl LoaderState {
             .map(|h| h.refs.fetch_add(num_refs, Ordering::Relaxed));
         handle
     }
+
     fn get_asset(&self, load: LoadHandle) -> Option<AssetTypeId> {
         let load = if load.is_indirect() {
             self.indirect_table.resolve(load)?
@@ -491,6 +493,7 @@ impl LoaderState {
             //     }
         }
     }
+
     fn process_metadata_requests(&self, io: &mut dyn LoaderIO) {
         while let Ok(mut response) = self.responses.metadata_rx.try_recv() {
             let request_data = &mut response.1;
@@ -667,6 +670,7 @@ impl LoaderState {
             io.get_artifacts(assets_to_request);
         }
     }
+
     fn process_load_ops(&self, asset_storage: &dyn AssetStorage) {
         while let Ok(op) = self.op_rx.try_recv() {
             match op {
@@ -720,6 +724,7 @@ impl LoaderState {
             }
         }
     }
+
     /// Checks for changed assets that need to be reloaded or unloaded
     fn process_asset_changes(&mut self, asset_storage: &dyn AssetStorage) {
         if self.pending_reloads.is_empty() {
@@ -897,6 +902,7 @@ impl LoaderInfoProvider for LoaderState {
     fn get_load_handle(&self, id: &AssetRef) -> Option<LoadHandle> {
         self.uuid_to_load.get(id.expect_uuid()).map(|l| *l)
     }
+
     fn get_asset_id(&self, load: LoadHandle) -> Option<AssetUuid> {
         self.load_states.get(&load).map(|l| l.asset_id)
     }
@@ -906,6 +912,7 @@ impl Loader {
     pub fn new(io: Box<dyn LoaderIO>) -> Loader {
         Self::new_with_handle_allocator(io, Arc::new(AtomicHandleAllocator::default()))
     }
+
     pub fn new_with_handle_allocator(
         io: Box<dyn LoaderIO>,
         handle_allocator: Arc<dyn HandleAllocator>,
@@ -966,6 +973,7 @@ impl Loader {
     pub fn get_load(&self, id: AssetUuid) -> Option<LoadHandle> {
         self.data.uuid_to_load.get(&id).map(|l| *l)
     }
+
     /// Returns the number of references to an asset.
     ///
     /// **Note:** The information is true at the time the `LoadInfo` is retrieved. The actual number
@@ -1055,6 +1063,7 @@ impl Loader {
     pub fn get_asset_type(&self, load: LoadHandle) -> Option<AssetTypeId> {
         self.data.get_asset(load)
     }
+
     /// Removes a reference to an asset.
     ///
     /// # Parameters

--- a/loader/src/packfile_io.rs
+++ b/loader/src/packfile_io.rs
@@ -1,17 +1,20 @@
-use crate::io::{DataRequest, LoaderIO, MetadataRequest, ResolveRequest};
-use crate::loader::LoaderState;
-use atelier_core::{utils::make_array, ArtifactMetadata, AssetMetadata, AssetRef, AssetUuid};
-use atelier_schema::pack::pack_file;
-
-use capnp::serialize::SliceSegments;
-use memmap::{Mmap, MmapOptions};
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
     mem::ManuallyDrop,
     sync::Arc,
 };
+
+use atelier_core::{utils::make_array, ArtifactMetadata, AssetMetadata, AssetRef, AssetUuid};
+use atelier_schema::pack::pack_file;
+use capnp::serialize::SliceSegments;
+use memmap::{Mmap, MmapOptions};
 use thread_local::ThreadLocal;
+
+use crate::{
+    io::{DataRequest, LoaderIO, MetadataRequest, ResolveRequest},
+    loader::LoaderState,
+};
 
 struct PackfileMessageReader {
     file: ManuallyDrop<File>,

--- a/loader/src/packfile_io.rs
+++ b/loader/src/packfile_io.rs
@@ -30,6 +30,7 @@ impl PackfileMessageReader {
             message_reader: ManuallyDrop::new(ThreadLocal::new()),
         })
     }
+
     fn get_reader(&self) -> capnp::Result<pack_file::Reader<'_>> {
         let messge_reader = self.message_reader.get_or_try(|| {
             // We ensure that the reader is dropped before the mmap so it's ok to cast to 'static here

--- a/loader/src/rpc_io.rs
+++ b/loader/src/rpc_io.rs
@@ -1,19 +1,21 @@
+use std::{error::Error, path::PathBuf, sync::Mutex};
+
 use atelier_core::{utils, ArtifactMetadata, AssetMetadata, AssetUuid};
 use atelier_schema::{data::asset_change_event, parse_db_metadata, service::asset_hub};
 use capnp::message::ReaderOptions;
 use capnp_rpc::{pry, rpc_twoparty_capnp, twoparty, RpcSystem};
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use futures_util::AsyncReadExt;
-use std::sync::Mutex;
-use std::{error::Error, path::PathBuf};
 use tokio::{
     net::TcpStream,
     runtime::{Builder, Runtime},
     sync::oneshot,
 };
 
-use crate::io::{DataRequest, LoaderIO, MetadataRequest, ResolveRequest};
-use crate::loader::LoaderState;
+use crate::{
+    io::{DataRequest, LoaderIO, MetadataRequest, ResolveRequest},
+    loader::LoaderState,
+};
 
 type Promise<T> = capnp::capability::Promise<T, capnp::Error>;
 
@@ -137,9 +139,11 @@ impl RpcRuntime {
 
                 let mut request = hub.register_listener_request();
                 request.get().set_listener(listener);
-                let rpc_conn = request.send().promise.await.map(|_| RpcConnection {
-                    snapshot,
-                    snapshot_rx,
+                let rpc_conn = request.send().promise.await.map(|_| {
+                    RpcConnection {
+                        snapshot,
+                        snapshot_rx,
+                    }
                 })?;
 
                 Ok(rpc_conn)
@@ -225,10 +229,12 @@ impl LoaderIO for RpcIO {
                 // update connection state
                 InternalConnectionState::Connecting(mut pending_connection) => {
                     match pending_connection.try_recv() {
-                        Ok(connection_result) => match connection_result {
-                            Ok(conn) => InternalConnectionState::Connected(conn),
-                            Err(err) => InternalConnectionState::Error(err),
-                        },
+                        Ok(connection_result) => {
+                            match connection_result {
+                                Ok(conn) => InternalConnectionState::Connected(conn),
+                                Err(err) => InternalConnectionState::Error(err),
+                            }
+                        }
                         Err(oneshot::error::TryRecvError::Closed) => {
                             InternalConnectionState::Error(Box::new(
                                 oneshot::error::TryRecvError::Closed,

--- a/loader/src/storage.rs
+++ b/loader/src/storage.rs
@@ -1,6 +1,3 @@
-use atelier_core::{AssetMetadata, AssetRef, AssetTypeId, AssetUuid};
-use crossbeam_channel::Sender;
-use dashmap::DashMap;
 use std::{
     error::Error,
     path::PathBuf,
@@ -9,6 +6,10 @@ use std::{
         Arc,
     },
 };
+
+use atelier_core::{AssetMetadata, AssetRef, AssetTypeId, AssetUuid};
+use crossbeam_channel::Sender;
+use dashmap::DashMap;
 
 /// Loading ID allocated by [`Loader`](crate::loader::Loader) to track loading of a particular asset
 /// or an indirect reference to an asset.

--- a/loader/src/storage.rs
+++ b/loader/src/storage.rs
@@ -213,6 +213,7 @@ impl HandleAllocator for AtomicHandleAllocator {
     fn alloc(&self) -> LoadHandle {
         LoadHandle(self.0.fetch_add(1, Ordering::Relaxed))
     }
+
     fn free(&self, _handle: LoadHandle) {}
 }
 
@@ -220,6 +221,7 @@ impl HandleAllocator for &'static AtomicHandleAllocator {
     fn alloc(&self) -> LoadHandle {
         LoadHandle(self.0.fetch_add(1, Ordering::Relaxed))
     }
+
     fn free(&self, _handle: LoadHandle) {}
 }
 
@@ -238,6 +240,7 @@ impl IndirectIdentifier {
             IndirectIdentifier::Path(path) => path.as_str(),
         }
     }
+
     pub fn type_id(&self) -> Option<&AssetTypeId> {
         match self {
             IndirectIdentifier::PathWithTagAndType(_, _, ty) => Some(ty),

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+unstable_features = true
+reorder_imports = true
+merge_imports = true
+group_imports = "StdExternalCrate"
+force_multiline_blocks = true
+format_code_in_doc_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,3 +4,5 @@ merge_imports = true
 group_imports = "StdExternalCrate"
 force_multiline_blocks = true
 format_code_in_doc_comments = true
+normalize_doc_attributes = true
+reorder_impl_items = true

--- a/schema/src/lib.rs
+++ b/schema/src/lib.rs
@@ -1,7 +1,8 @@
 mod schemas;
+use std::path::PathBuf;
+
 use atelier_core::{utils::make_array, ArtifactId, ArtifactMetadata, AssetMetadata, AssetRef};
 pub use schemas::{data_capnp, pack_capnp, service_capnp};
-use std::path::PathBuf;
 impl ::std::fmt::Debug for data_capnp::FileState {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         match self {
@@ -59,14 +60,18 @@ fn set_assetref_list(
 
 pub fn parse_db_asset_ref(asset_ref: &data::asset_ref::Reader<'_>) -> AssetRef {
     match asset_ref.which().expect("capnp: failed to read asset ref") {
-        data::asset_ref::Path(p) => AssetRef::Path(PathBuf::from(
-            std::str::from_utf8(p.expect("capnp: failed to read asset ref path"))
-                .expect("capnp: failed to parse utf8 string"),
-        )),
-        data::asset_ref::Uuid(uuid) => AssetRef::Uuid(make_array(
-            uuid.and_then(|id| id.get_id())
-                .expect("capnp: failed to read asset ref uuid"),
-        )),
+        data::asset_ref::Path(p) => {
+            AssetRef::Path(PathBuf::from(
+                std::str::from_utf8(p.expect("capnp: failed to read asset ref path"))
+                    .expect("capnp: failed to parse utf8 string"),
+            ))
+        }
+        data::asset_ref::Uuid(uuid) => {
+            AssetRef::Uuid(make_array(
+                uuid.and_then(|id| id.get_id())
+                    .expect("capnp: failed to read asset ref uuid"),
+            ))
+        }
     }
 }
 

--- a/schema/src/schemas/data_capnp.rs
+++ b/schema/src/schemas/data_capnp.rs
@@ -6,12 +6,12 @@ pub mod asset_uuid {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -66,6 +66,7 @@ pub mod asset_uuid {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -73,6 +74,7 @@ pub mod asset_uuid {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_id(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -113,6 +115,7 @@ pub mod asset_uuid {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -137,9 +140,11 @@ pub mod asset_uuid {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -147,6 +152,7 @@ pub mod asset_uuid {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -154,14 +160,17 @@ pub mod asset_uuid {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_id(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_id(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_id(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -194,12 +203,12 @@ pub mod asset_ref {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -254,18 +263,21 @@ pub mod asset_ref {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         pub fn has_uuid(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 0 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+
         pub fn has_path(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 1 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(0) {
@@ -325,6 +337,7 @@ pub mod asset_ref {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -349,9 +362,11 @@ pub mod asset_ref {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -359,6 +374,7 @@ pub mod asset_ref {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn set_uuid(
             &mut self,
@@ -371,33 +387,39 @@ pub mod asset_ref {
                 false,
             )
         }
+
         #[inline]
         pub fn init_uuid(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             self.builder.set_data_field::<u16>(0, 0);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_uuid(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 0 {
                 return false;
             }
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.set_data_field::<u16>(0, 1);
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.set_data_field::<u16>(0, 1);
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_path(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 1 {
                 return false;
             }
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(0) {
@@ -459,12 +481,12 @@ pub mod asset_uuid_list {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -519,6 +541,7 @@ pub mod asset_uuid_list {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_list(
             self,
@@ -529,6 +552,7 @@ pub mod asset_uuid_list {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_list(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -569,6 +593,7 @@ pub mod asset_uuid_list {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -593,9 +618,11 @@ pub mod asset_uuid_list {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -603,6 +630,7 @@ pub mod asset_uuid_list {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_list(
             self,
@@ -613,6 +641,7 @@ pub mod asset_uuid_list {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_list(
             &mut self,
@@ -624,6 +653,7 @@ pub mod asset_uuid_list {
                 false,
             )
         }
+
         #[inline]
         pub fn init_list(
             self,
@@ -634,6 +664,7 @@ pub mod asset_uuid_list {
                 size,
             )
         }
+
         pub fn has_list(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -664,12 +695,12 @@ pub mod key_value {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -724,6 +755,7 @@ pub mod key_value {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_key(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -731,9 +763,11 @@ pub mod key_value {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_key(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_value(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -741,6 +775,7 @@ pub mod key_value {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_value(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -781,6 +816,7 @@ pub mod key_value {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -805,9 +841,11 @@ pub mod key_value {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -815,6 +853,7 @@ pub mod key_value {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_key(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -822,17 +861,21 @@ pub mod key_value {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_key(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_key(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_key(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_value(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -840,14 +883,17 @@ pub mod key_value {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_value(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_value(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_value(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -940,12 +986,12 @@ pub mod dirty_file_info {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -1000,12 +1046,14 @@ pub mod dirty_file_info {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_state(
             self,
         ) -> ::core::result::Result<crate::data_capnp::FileState, ::capnp::NotInSchema> {
             ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(0))
         }
+
         #[inline]
         pub fn get_source_info(
             self,
@@ -1015,6 +1063,7 @@ pub mod dirty_file_info {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_source_info(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -1055,6 +1104,7 @@ pub mod dirty_file_info {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1079,9 +1129,11 @@ pub mod dirty_file_info {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -1089,16 +1141,19 @@ pub mod dirty_file_info {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_state(
             self,
         ) -> ::core::result::Result<crate::data_capnp::FileState, ::capnp::NotInSchema> {
             ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(0))
         }
+
         #[inline]
         pub fn set_state(&mut self, value: crate::data_capnp::FileState) {
             self.builder.set_data_field::<u16>(0, value as u16)
         }
+
         #[inline]
         pub fn get_source_info(
             self,
@@ -1108,6 +1163,7 @@ pub mod dirty_file_info {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_source_info(
             &mut self,
@@ -1119,10 +1175,12 @@ pub mod dirty_file_info {
                 false,
             )
         }
+
         #[inline]
         pub fn init_source_info(self) -> crate::data_capnp::source_file_info::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_source_info(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -1157,12 +1215,12 @@ pub mod source_file_info {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -1217,16 +1275,19 @@ pub mod source_file_info {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_type(
             self,
         ) -> ::core::result::Result<crate::data_capnp::FileType, ::capnp::NotInSchema> {
             ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(0))
         }
+
         #[inline]
         pub fn get_last_modified(self) -> u64 {
             self.reader.get_data_field::<u64>(1)
         }
+
         #[inline]
         pub fn get_length(self) -> u64 {
             self.reader.get_data_field::<u64>(2)
@@ -1268,6 +1329,7 @@ pub mod source_file_info {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1292,9 +1354,11 @@ pub mod source_file_info {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -1302,28 +1366,34 @@ pub mod source_file_info {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_type(
             self,
         ) -> ::core::result::Result<crate::data_capnp::FileType, ::capnp::NotInSchema> {
             ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(0))
         }
+
         #[inline]
         pub fn set_type(&mut self, value: crate::data_capnp::FileType) {
             self.builder.set_data_field::<u16>(0, value as u16)
         }
+
         #[inline]
         pub fn get_last_modified(self) -> u64 {
             self.builder.get_data_field::<u64>(1)
         }
+
         #[inline]
         pub fn set_last_modified(&mut self, value: u64) {
             self.builder.set_data_field::<u64>(1, value);
         }
+
         #[inline]
         pub fn get_length(self) -> u64 {
             self.builder.get_data_field::<u64>(2)
         }
+
         #[inline]
         pub fn set_length(&mut self, value: u64) {
             self.builder.set_data_field::<u64>(2, value);
@@ -1355,12 +1425,12 @@ pub mod rename_file_event {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -1415,6 +1485,7 @@ pub mod rename_file_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_src(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1422,9 +1493,11 @@ pub mod rename_file_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_src(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_dst(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1432,6 +1505,7 @@ pub mod rename_file_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_dst(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -1472,6 +1546,7 @@ pub mod rename_file_event {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1496,9 +1571,11 @@ pub mod rename_file_event {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -1506,6 +1583,7 @@ pub mod rename_file_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_src(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -1513,17 +1591,21 @@ pub mod rename_file_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_src(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_src(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_src(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_dst(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -1531,14 +1613,17 @@ pub mod rename_file_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_dst(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_dst(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_dst(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -1596,12 +1681,12 @@ pub mod asset_uuid_pair {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -1656,6 +1741,7 @@ pub mod asset_uuid_pair {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_key(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1663,9 +1749,11 @@ pub mod asset_uuid_pair {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_key(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_value(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1673,6 +1761,7 @@ pub mod asset_uuid_pair {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_value(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -1713,6 +1802,7 @@ pub mod asset_uuid_pair {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1737,9 +1827,11 @@ pub mod asset_uuid_pair {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -1747,6 +1839,7 @@ pub mod asset_uuid_pair {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_key(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -1754,6 +1847,7 @@ pub mod asset_uuid_pair {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_key(
             &mut self,
@@ -1765,13 +1859,16 @@ pub mod asset_uuid_pair {
                 false,
             )
         }
+
         #[inline]
         pub fn init_key(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_key(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_value(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -1779,6 +1876,7 @@ pub mod asset_uuid_pair {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_value(
             &mut self,
@@ -1790,10 +1888,12 @@ pub mod asset_uuid_pair {
                 false,
             )
         }
+
         #[inline]
         pub fn init_value(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
         }
+
         pub fn has_value(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -1813,6 +1913,7 @@ pub mod asset_uuid_pair {
         pub fn get_key(&self) -> crate::data_capnp::asset_uuid::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
         }
+
         pub fn get_value(&self) -> crate::data_capnp::asset_uuid::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
         }
@@ -1833,12 +1934,12 @@ pub mod source_metadata {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -1893,6 +1994,7 @@ pub mod source_metadata {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_assets(
             self,
@@ -1904,13 +2006,16 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_assets(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_importer_version(self) -> u32 {
             self.reader.get_data_field::<u32>(0)
         }
+
         #[inline]
         pub fn get_importer_options_type(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1918,9 +2023,11 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_importer_options_type(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_importer_options(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1928,9 +2035,11 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_importer_options(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
+
         #[inline]
         pub fn get_importer_state_type(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1938,9 +2047,11 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_importer_state_type(&self) -> bool {
             !self.reader.get_pointer_field(3).is_null()
         }
+
         #[inline]
         pub fn get_importer_state(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1948,9 +2059,11 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_importer_state(&self) -> bool {
             !self.reader.get_pointer_field(4).is_null()
         }
+
         #[inline]
         pub fn get_build_pipelines(
             self,
@@ -1962,9 +2075,11 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_build_pipelines(&self) -> bool {
             !self.reader.get_pointer_field(5).is_null()
         }
+
         #[inline]
         pub fn get_importer_type(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1972,15 +2087,18 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_importer_type(&self) -> bool {
             !self.reader.get_pointer_field(6).is_null()
         }
+
         pub fn has_error(&self) -> bool {
             if self.reader.get_data_field::<u16>(2) != 0 {
                 return false;
             }
             !self.reader.get_pointer_field(7).is_null()
         }
+
         #[inline]
         pub fn get_path_refs(self) -> ::capnp::Result<::capnp::data_list::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1988,9 +2106,11 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_path_refs(&self) -> bool {
             !self.reader.get_pointer_field(8).is_null()
         }
+
         #[inline]
         pub fn get_import_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -1998,13 +2118,16 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_import_hash(&self) -> bool {
             !self.reader.get_pointer_field(9).is_null()
         }
+
         #[inline]
         pub fn get_version(self) -> u32 {
             self.reader.get_data_field::<u32>(2)
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(2) {
@@ -2057,6 +2180,7 @@ pub mod source_metadata {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2081,9 +2205,11 @@ pub mod source_metadata {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -2091,6 +2217,7 @@ pub mod source_metadata {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_assets(
             self,
@@ -2102,6 +2229,7 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_assets(
             &mut self,
@@ -2113,6 +2241,7 @@ pub mod source_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_assets(
             self,
@@ -2123,17 +2252,21 @@ pub mod source_metadata {
                 size,
             )
         }
+
         pub fn has_assets(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_importer_version(self) -> u32 {
             self.builder.get_data_field::<u32>(0)
         }
+
         #[inline]
         pub fn set_importer_version(&mut self, value: u32) {
             self.builder.set_data_field::<u32>(0, value);
         }
+
         #[inline]
         pub fn get_importer_options_type(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2141,17 +2274,21 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_importer_options_type(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_importer_options_type(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_importer_options_type(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_importer_options(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2159,17 +2296,21 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_importer_options(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(2).set_data(value);
         }
+
         #[inline]
         pub fn init_importer_options(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(2).init_data(size)
         }
+
         pub fn has_importer_options(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
+
         #[inline]
         pub fn get_importer_state_type(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2177,17 +2318,21 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_importer_state_type(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(3).set_data(value);
         }
+
         #[inline]
         pub fn init_importer_state_type(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(3).init_data(size)
         }
+
         pub fn has_importer_state_type(&self) -> bool {
             !self.builder.get_pointer_field(3).is_null()
         }
+
         #[inline]
         pub fn get_importer_state(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2195,17 +2340,21 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_importer_state(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(4).set_data(value);
         }
+
         #[inline]
         pub fn init_importer_state(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(4).init_data(size)
         }
+
         pub fn has_importer_state(&self) -> bool {
             !self.builder.get_pointer_field(4).is_null()
         }
+
         #[inline]
         pub fn get_build_pipelines(
             self,
@@ -2217,6 +2366,7 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_build_pipelines(
             &mut self,
@@ -2228,6 +2378,7 @@ pub mod source_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_build_pipelines(
             self,
@@ -2238,9 +2389,11 @@ pub mod source_metadata {
                 size,
             )
         }
+
         pub fn has_build_pipelines(&self) -> bool {
             !self.builder.get_pointer_field(5).is_null()
         }
+
         #[inline]
         pub fn get_importer_type(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2248,17 +2401,21 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_importer_type(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(6).set_data(value);
         }
+
         #[inline]
         pub fn init_importer_type(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(6).init_data(size)
         }
+
         pub fn has_importer_type(&self) -> bool {
             !self.builder.get_pointer_field(6).is_null()
         }
+
         #[inline]
         pub fn set_error(
             &mut self,
@@ -2271,21 +2428,25 @@ pub mod source_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_error(self) -> crate::data_capnp::error::Builder<'a> {
             self.builder.set_data_field::<u16>(2, 0);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(7), 0)
         }
+
         pub fn has_error(&self) -> bool {
             if self.builder.get_data_field::<u16>(2) != 0 {
                 return false;
             }
             !self.builder.get_pointer_field(7).is_null()
         }
+
         #[inline]
         pub fn set_no_error(&mut self, _value: ()) {
             self.builder.set_data_field::<u16>(2, 1);
         }
+
         #[inline]
         pub fn get_path_refs(self) -> ::capnp::Result<::capnp::data_list::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2293,6 +2454,7 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_path_refs(
             &mut self,
@@ -2304,6 +2466,7 @@ pub mod source_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_path_refs(self, size: u32) -> ::capnp::data_list::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(
@@ -2311,9 +2474,11 @@ pub mod source_metadata {
                 size,
             )
         }
+
         pub fn has_path_refs(&self) -> bool {
             !self.builder.get_pointer_field(8).is_null()
         }
+
         #[inline]
         pub fn get_import_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2321,25 +2486,31 @@ pub mod source_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_import_hash(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(9).set_data(value);
         }
+
         #[inline]
         pub fn init_import_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(9).init_data(size)
         }
+
         pub fn has_import_hash(&self) -> bool {
             !self.builder.get_pointer_field(9).is_null()
         }
+
         #[inline]
         pub fn get_version(self) -> u32 {
             self.builder.get_data_field::<u32>(2)
         }
+
         #[inline]
         pub fn set_version(&mut self, value: u32) {
             self.builder.set_data_field::<u32>(2, value);
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(2) {
@@ -2388,12 +2559,12 @@ pub mod path_refs {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -2448,6 +2619,7 @@ pub mod path_refs {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_paths(self) -> ::capnp::Result<::capnp::data_list::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -2455,6 +2627,7 @@ pub mod path_refs {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_paths(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -2495,6 +2668,7 @@ pub mod path_refs {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2519,9 +2693,11 @@ pub mod path_refs {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -2529,6 +2705,7 @@ pub mod path_refs {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_paths(self) -> ::capnp::Result<::capnp::data_list::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2536,6 +2713,7 @@ pub mod path_refs {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_paths(&mut self, value: ::capnp::data_list::Reader<'a>) -> ::capnp::Result<()> {
             ::capnp::traits::SetPointerBuilder::set_pointer_builder(
@@ -2544,6 +2722,7 @@ pub mod path_refs {
                 false,
             )
         }
+
         #[inline]
         pub fn init_paths(self, size: u32) -> ::capnp::data_list::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(
@@ -2551,6 +2730,7 @@ pub mod path_refs {
                 size,
             )
         }
+
         pub fn has_paths(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -2581,12 +2761,12 @@ pub mod error {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -2641,6 +2821,7 @@ pub mod error {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_text(self) -> ::capnp::Result<::capnp::text::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -2648,6 +2829,7 @@ pub mod error {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_text(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -2688,6 +2870,7 @@ pub mod error {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2712,9 +2895,11 @@ pub mod error {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -2722,6 +2907,7 @@ pub mod error {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_text(self) -> ::capnp::Result<::capnp::text::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2729,14 +2915,17 @@ pub mod error {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_text(&mut self, value: ::capnp::text::Reader<'_>) {
             self.builder.get_pointer_field(0).set_text(value);
         }
+
         #[inline]
         pub fn init_text(self, size: u32) -> ::capnp::text::Builder<'a> {
             self.builder.get_pointer_field(0).init_text(size)
         }
+
         pub fn has_text(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -2767,12 +2956,12 @@ pub mod artifact_metadata {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -2827,6 +3016,7 @@ pub mod artifact_metadata {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_asset_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -2834,9 +3024,11 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_asset_id(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -2844,9 +3036,11 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_hash(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_load_deps(
             self,
@@ -2857,9 +3051,11 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_load_deps(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
+
         #[inline]
         pub fn get_build_deps(
             self,
@@ -2870,9 +3066,11 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_build_deps(&self) -> bool {
             !self.reader.get_pointer_field(3).is_null()
         }
+
         #[inline]
         pub fn get_compression(
             self,
@@ -2880,14 +3078,17 @@ pub mod artifact_metadata {
         {
             ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(0))
         }
+
         #[inline]
         pub fn get_compressed_size(self) -> u64 {
             self.reader.get_data_field::<u64>(1)
         }
+
         #[inline]
         pub fn get_uncompressed_size(self) -> u64 {
             self.reader.get_data_field::<u64>(2)
         }
+
         #[inline]
         pub fn get_type_id(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -2895,6 +3096,7 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_type_id(&self) -> bool {
             !self.reader.get_pointer_field(4).is_null()
         }
@@ -2935,6 +3137,7 @@ pub mod artifact_metadata {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2959,9 +3162,11 @@ pub mod artifact_metadata {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -2969,6 +3174,7 @@ pub mod artifact_metadata {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_asset_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -2976,6 +3182,7 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_asset_id(
             &mut self,
@@ -2987,13 +3194,16 @@ pub mod artifact_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_asset_id(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_asset_id(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -3001,17 +3211,21 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_hash(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_hash(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_load_deps(
             self,
@@ -3022,6 +3236,7 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_load_deps(
             &mut self,
@@ -3033,6 +3248,7 @@ pub mod artifact_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_load_deps(
             self,
@@ -3043,9 +3259,11 @@ pub mod artifact_metadata {
                 size,
             )
         }
+
         pub fn has_load_deps(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
+
         #[inline]
         pub fn get_build_deps(
             self,
@@ -3056,6 +3274,7 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_build_deps(
             &mut self,
@@ -3067,6 +3286,7 @@ pub mod artifact_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_build_deps(
             self,
@@ -3077,9 +3297,11 @@ pub mod artifact_metadata {
                 size,
             )
         }
+
         pub fn has_build_deps(&self) -> bool {
             !self.builder.get_pointer_field(3).is_null()
         }
+
         #[inline]
         pub fn get_compression(
             self,
@@ -3087,26 +3309,32 @@ pub mod artifact_metadata {
         {
             ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(0))
         }
+
         #[inline]
         pub fn set_compression(&mut self, value: crate::data_capnp::CompressionType) {
             self.builder.set_data_field::<u16>(0, value as u16)
         }
+
         #[inline]
         pub fn get_compressed_size(self) -> u64 {
             self.builder.get_data_field::<u64>(1)
         }
+
         #[inline]
         pub fn set_compressed_size(&mut self, value: u64) {
             self.builder.set_data_field::<u64>(1, value);
         }
+
         #[inline]
         pub fn get_uncompressed_size(self) -> u64 {
             self.builder.get_data_field::<u64>(2)
         }
+
         #[inline]
         pub fn set_uncompressed_size(&mut self, value: u64) {
             self.builder.set_data_field::<u64>(2, value);
         }
+
         #[inline]
         pub fn get_type_id(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -3114,14 +3342,17 @@ pub mod artifact_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_type_id(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(4).set_data(value);
         }
+
         #[inline]
         pub fn init_type_id(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(4).init_data(size)
         }
+
         pub fn has_type_id(&self) -> bool {
             !self.builder.get_pointer_field(4).is_null()
         }
@@ -3158,12 +3389,12 @@ pub mod asset_metadata {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -3218,6 +3449,7 @@ pub mod asset_metadata {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -3225,9 +3457,11 @@ pub mod asset_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_id(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_search_tags(
             self,
@@ -3238,9 +3472,11 @@ pub mod asset_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_search_tags(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_build_pipeline(
             self,
@@ -3250,27 +3486,32 @@ pub mod asset_metadata {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_build_pipeline(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
+
         #[inline]
         pub fn get_latest_artifact(
             self,
         ) -> crate::data_capnp::asset_metadata::latest_artifact::Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.reader)
         }
+
         #[inline]
         pub fn get_source(
             self,
         ) -> ::core::result::Result<crate::data_capnp::AssetSource, ::capnp::NotInSchema> {
             ::capnp::traits::FromU16::from_u16(self.reader.get_data_field::<u16>(1))
         }
+
         pub fn has_error(&self) -> bool {
             if self.reader.get_data_field::<u16>(2) != 0 {
                 return false;
             }
             !self.reader.get_pointer_field(4).is_null()
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(2) {
@@ -3323,6 +3564,7 @@ pub mod asset_metadata {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3347,9 +3589,11 @@ pub mod asset_metadata {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -3357,6 +3601,7 @@ pub mod asset_metadata {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -3364,6 +3609,7 @@ pub mod asset_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_id(
             &mut self,
@@ -3375,13 +3621,16 @@ pub mod asset_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_id(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_id(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_search_tags(
             self,
@@ -3392,6 +3641,7 @@ pub mod asset_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_search_tags(
             &mut self,
@@ -3403,6 +3653,7 @@ pub mod asset_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_search_tags(
             self,
@@ -3413,9 +3664,11 @@ pub mod asset_metadata {
                 size,
             )
         }
+
         pub fn has_search_tags(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_build_pipeline(
             self,
@@ -3425,6 +3678,7 @@ pub mod asset_metadata {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_build_pipeline(
             &mut self,
@@ -3436,19 +3690,23 @@ pub mod asset_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_build_pipeline(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
         }
+
         pub fn has_build_pipeline(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
+
         #[inline]
         pub fn get_latest_artifact(
             self,
         ) -> crate::data_capnp::asset_metadata::latest_artifact::Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(self.builder)
         }
+
         #[inline]
         pub fn init_latest_artifact(
             self,
@@ -3457,16 +3715,19 @@ pub mod asset_metadata {
             self.builder.get_pointer_field(3).clear();
             ::capnp::traits::FromStructBuilder::new(self.builder)
         }
+
         #[inline]
         pub fn get_source(
             self,
         ) -> ::core::result::Result<crate::data_capnp::AssetSource, ::capnp::NotInSchema> {
             ::capnp::traits::FromU16::from_u16(self.builder.get_data_field::<u16>(1))
         }
+
         #[inline]
         pub fn set_source(&mut self, value: crate::data_capnp::AssetSource) {
             self.builder.set_data_field::<u16>(1, value as u16)
         }
+
         #[inline]
         pub fn set_error(
             &mut self,
@@ -3479,21 +3740,25 @@ pub mod asset_metadata {
                 false,
             )
         }
+
         #[inline]
         pub fn init_error(self) -> crate::data_capnp::error::Builder<'a> {
             self.builder.set_data_field::<u16>(2, 0);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(4), 0)
         }
+
         pub fn has_error(&self) -> bool {
             if self.builder.get_data_field::<u16>(2) != 0 {
                 return false;
             }
             !self.builder.get_pointer_field(4).is_null()
         }
+
         #[inline]
         pub fn set_no_error(&mut self, _value: ()) {
             self.builder.set_data_field::<u16>(2, 1);
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(2) {
@@ -3525,9 +3790,11 @@ pub mod asset_metadata {
         pub fn get_id(&self) -> crate::data_capnp::asset_uuid::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
         }
+
         pub fn get_build_pipeline(&self) -> crate::data_capnp::asset_uuid::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
         }
+
         pub fn get_latest_artifact(
             &self,
         ) -> crate::data_capnp::asset_metadata::latest_artifact::Pipeline {
@@ -3555,12 +3822,12 @@ pub mod asset_metadata {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Pipeline;
@@ -3615,12 +3882,14 @@ pub mod asset_metadata {
             pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                 self.reader.total_size()
             }
+
             pub fn has_artifact(&self) -> bool {
                 if self.reader.get_data_field::<u16>(0) != 0 {
                     return false;
                 }
                 !self.reader.get_pointer_field(3).is_null()
             }
+
             #[inline]
             pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
                 match self.reader.get_data_field::<u16>(0) {
@@ -3673,6 +3942,7 @@ pub mod asset_metadata {
             ) -> Builder<'a> {
                 ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3697,9 +3967,11 @@ pub mod asset_metadata {
             pub fn into_reader(self) -> Reader<'a> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
+
             pub fn reborrow(&mut self) -> Builder<'_> {
                 Builder { ..*self }
             }
+
             pub fn reborrow_as_reader(&self) -> Reader<'_> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
@@ -3707,6 +3979,7 @@ pub mod asset_metadata {
             pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                 self.builder.into_reader().total_size()
             }
+
             #[inline]
             pub fn set_artifact(
                 &mut self,
@@ -3719,6 +3992,7 @@ pub mod asset_metadata {
                     false,
                 )
             }
+
             #[inline]
             pub fn init_artifact(self) -> crate::data_capnp::artifact_metadata::Builder<'a> {
                 self.builder.set_data_field::<u16>(0, 0);
@@ -3727,16 +4001,19 @@ pub mod asset_metadata {
                     0,
                 )
             }
+
             pub fn has_artifact(&self) -> bool {
                 if self.builder.get_data_field::<u16>(0) != 0 {
                     return false;
                 }
                 !self.builder.get_pointer_field(3).is_null()
             }
+
             #[inline]
             pub fn set_none(&mut self, _value: ()) {
                 self.builder.set_data_field::<u16>(0, 1);
             }
+
             #[inline]
             pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
                 match self.builder.get_data_field::<u16>(0) {
@@ -3788,12 +4065,12 @@ pub mod artifact {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -3848,6 +4125,7 @@ pub mod artifact {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_metadata(
             self,
@@ -3857,9 +4135,11 @@ pub mod artifact {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_metadata(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_data(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -3867,6 +4147,7 @@ pub mod artifact {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_data(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -3907,6 +4188,7 @@ pub mod artifact {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3931,9 +4213,11 @@ pub mod artifact {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -3941,6 +4225,7 @@ pub mod artifact {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_metadata(
             self,
@@ -3950,6 +4235,7 @@ pub mod artifact {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_metadata(
             &mut self,
@@ -3961,13 +4247,16 @@ pub mod artifact {
                 false,
             )
         }
+
         #[inline]
         pub fn init_metadata(self) -> crate::data_capnp::artifact_metadata::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_metadata(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_data(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -3975,14 +4264,17 @@ pub mod artifact {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_data(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_data(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_data(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -4017,12 +4309,12 @@ pub mod build_parameters {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -4114,6 +4406,7 @@ pub mod build_parameters {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4138,9 +4431,11 @@ pub mod build_parameters {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -4175,12 +4470,12 @@ pub mod asset_change_log_entry {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -4235,10 +4530,12 @@ pub mod asset_change_log_entry {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_num(self) -> u64 {
             self.reader.get_data_field::<u64>(0)
         }
+
         #[inline]
         pub fn get_event(
             self,
@@ -4248,6 +4545,7 @@ pub mod asset_change_log_entry {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_event(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -4288,6 +4586,7 @@ pub mod asset_change_log_entry {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4312,9 +4611,11 @@ pub mod asset_change_log_entry {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -4322,14 +4623,17 @@ pub mod asset_change_log_entry {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_num(self) -> u64 {
             self.builder.get_data_field::<u64>(0)
         }
+
         #[inline]
         pub fn set_num(&mut self, value: u64) {
             self.builder.set_data_field::<u64>(0, value);
         }
+
         #[inline]
         pub fn get_event(
             self,
@@ -4339,6 +4643,7 @@ pub mod asset_change_log_entry {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_event(
             &mut self,
@@ -4350,10 +4655,12 @@ pub mod asset_change_log_entry {
                 false,
             )
         }
+
         #[inline]
         pub fn init_event(self) -> crate::data_capnp::asset_change_event::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_event(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -4390,12 +4697,12 @@ pub mod asset_change_event {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -4450,30 +4757,35 @@ pub mod asset_change_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         pub fn has_content_update_event(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 0 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+
         pub fn has_remove_event(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 1 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+
         pub fn has_path_update_event(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 2 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+
         pub fn has_path_remove_event(&self) -> bool {
             if self.reader.get_data_field::<u16>(0) != 3 {
                 return false;
             }
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(0) {
@@ -4549,6 +4861,7 @@ pub mod asset_change_event {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4573,9 +4886,11 @@ pub mod asset_change_event {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -4583,6 +4898,7 @@ pub mod asset_change_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn set_content_update_event(
             &mut self,
@@ -4595,6 +4911,7 @@ pub mod asset_change_event {
                 false,
             )
         }
+
         #[inline]
         pub fn init_content_update_event(
             self,
@@ -4602,12 +4919,14 @@ pub mod asset_change_event {
             self.builder.set_data_field::<u16>(0, 0);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_content_update_event(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 0 {
                 return false;
             }
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn set_remove_event(
             &mut self,
@@ -4620,17 +4939,20 @@ pub mod asset_change_event {
                 false,
             )
         }
+
         #[inline]
         pub fn init_remove_event(self) -> crate::data_capnp::asset_remove_event::Builder<'a> {
             self.builder.set_data_field::<u16>(0, 1);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_remove_event(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 1 {
                 return false;
             }
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn set_path_update_event(
             &mut self,
@@ -4643,17 +4965,20 @@ pub mod asset_change_event {
                 false,
             )
         }
+
         #[inline]
         pub fn init_path_update_event(self) -> crate::data_capnp::path_update_event::Builder<'a> {
             self.builder.set_data_field::<u16>(0, 2);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_path_update_event(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 2 {
                 return false;
             }
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn set_path_remove_event(
             &mut self,
@@ -4666,17 +4991,20 @@ pub mod asset_change_event {
                 false,
             )
         }
+
         #[inline]
         pub fn init_path_remove_event(self) -> crate::data_capnp::path_remove_event::Builder<'a> {
             self.builder.set_data_field::<u16>(0, 3);
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_path_remove_event(&self) -> bool {
             if self.builder.get_data_field::<u16>(0) != 3 {
                 return false;
             }
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(0) {
@@ -4760,12 +5088,12 @@ pub mod asset_content_update_event {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -4820,6 +5148,7 @@ pub mod asset_content_update_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -4827,9 +5156,11 @@ pub mod asset_content_update_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_id(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_import_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -4837,9 +5168,11 @@ pub mod asset_content_update_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_import_hash(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_build_dep_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -4847,6 +5180,7 @@ pub mod asset_content_update_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_build_dep_hash(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -4887,6 +5221,7 @@ pub mod asset_content_update_event {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4911,9 +5246,11 @@ pub mod asset_content_update_event {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -4921,6 +5258,7 @@ pub mod asset_content_update_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -4928,6 +5266,7 @@ pub mod asset_content_update_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_id(
             &mut self,
@@ -4939,13 +5278,16 @@ pub mod asset_content_update_event {
                 false,
             )
         }
+
         #[inline]
         pub fn init_id(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_id(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_import_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -4953,17 +5295,21 @@ pub mod asset_content_update_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_import_hash(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_import_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_import_hash(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_build_dep_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -4971,14 +5317,17 @@ pub mod asset_content_update_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_build_dep_hash(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(2).set_data(value);
         }
+
         #[inline]
         pub fn init_build_dep_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(2).init_data(size)
         }
+
         pub fn has_build_dep_hash(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
@@ -5013,12 +5362,12 @@ pub mod path_update_event {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -5073,6 +5422,7 @@ pub mod path_update_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5080,6 +5430,7 @@ pub mod path_update_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_path(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -5120,6 +5471,7 @@ pub mod path_update_event {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5144,9 +5496,11 @@ pub mod path_update_event {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -5154,6 +5508,7 @@ pub mod path_update_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -5161,14 +5516,17 @@ pub mod path_update_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_path(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -5199,12 +5557,12 @@ pub mod asset_remove_event {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -5259,6 +5617,7 @@ pub mod asset_remove_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5266,6 +5625,7 @@ pub mod asset_remove_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_id(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -5306,6 +5666,7 @@ pub mod asset_remove_event {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5330,9 +5691,11 @@ pub mod asset_remove_event {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -5340,6 +5703,7 @@ pub mod asset_remove_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -5347,6 +5711,7 @@ pub mod asset_remove_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_id(
             &mut self,
@@ -5358,10 +5723,12 @@ pub mod asset_remove_event {
                 false,
             )
         }
+
         #[inline]
         pub fn init_id(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_id(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -5396,12 +5763,12 @@ pub mod path_remove_event {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -5456,6 +5823,7 @@ pub mod path_remove_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5463,6 +5831,7 @@ pub mod path_remove_event {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_path(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -5503,6 +5872,7 @@ pub mod path_remove_event {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5527,9 +5897,11 @@ pub mod path_remove_event {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -5537,6 +5909,7 @@ pub mod path_remove_event {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -5544,14 +5917,17 @@ pub mod path_remove_event {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_path(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
@@ -5611,12 +5987,12 @@ pub mod daemon_info {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -5671,6 +6047,7 @@ pub mod daemon_info {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_version(self) -> u32 {
             self.reader.get_data_field::<u32>(0)
@@ -5712,6 +6089,7 @@ pub mod daemon_info {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5736,9 +6114,11 @@ pub mod daemon_info {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -5746,10 +6126,12 @@ pub mod daemon_info {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_version(self) -> u32 {
             self.builder.get_data_field::<u32>(0)
         }
+
         #[inline]
         pub fn set_version(&mut self, value: u32) {
             self.builder.set_data_field::<u32>(0, value);

--- a/schema/src/schemas/data_capnp.rs
+++ b/schema/src/schemas/data_capnp.rs
@@ -269,18 +269,22 @@ pub mod asset_ref {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(0) {
-                0 => ::core::result::Result::Ok(Uuid(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                1 => ::core::result::Result::Ok(Path(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(Uuid(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                1 => {
+                    ::core::result::Result::Ok(Path(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
         }
@@ -397,18 +401,22 @@ pub mod asset_ref {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(0) {
-                0 => ::core::result::Result::Ok(Uuid(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                1 => ::core::result::Result::Ok(Path(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(Uuid(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                1 => {
+                    ::core::result::Result::Ok(Path(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
         }
@@ -2000,12 +2008,14 @@ pub mod source_metadata {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(2) {
-                0 => ::core::result::Result::Ok(Error(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(7),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(Error(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(7),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 1 => ::core::result::Result::Ok(NoError(())),
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
@@ -2333,12 +2343,14 @@ pub mod source_metadata {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(2) {
-                0 => ::core::result::Result::Ok(Error(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(7),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(Error(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(7),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 1 => ::core::result::Result::Ok(NoError(())),
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
@@ -3262,12 +3274,14 @@ pub mod asset_metadata {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(2) {
-                0 => ::core::result::Result::Ok(Error(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(4),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(Error(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(4),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 1 => ::core::result::Result::Ok(NoError(())),
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
@@ -3483,12 +3497,14 @@ pub mod asset_metadata {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(2) {
-                0 => ::core::result::Result::Ok(Error(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(4),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(Error(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(4),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 1 => ::core::result::Result::Ok(NoError(())),
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
@@ -3608,12 +3624,14 @@ pub mod asset_metadata {
             #[inline]
             pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
                 match self.reader.get_data_field::<u16>(0) {
-                    0 => ::core::result::Result::Ok(Artifact(
-                        ::capnp::traits::FromPointerReader::get_from_pointer(
-                            &self.reader.get_pointer_field(3),
-                            ::core::option::Option::None,
-                        ),
-                    )),
+                    0 => {
+                        ::core::result::Result::Ok(Artifact(
+                            ::capnp::traits::FromPointerReader::get_from_pointer(
+                                &self.reader.get_pointer_field(3),
+                                ::core::option::Option::None,
+                            ),
+                        ))
+                    }
                     1 => ::core::result::Result::Ok(None(())),
                     x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
                 }
@@ -3722,12 +3740,14 @@ pub mod asset_metadata {
             #[inline]
             pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
                 match self.builder.get_data_field::<u16>(0) {
-                    0 => ::core::result::Result::Ok(Artifact(
-                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                            self.builder.get_pointer_field(3),
-                            ::core::option::Option::None,
-                        ),
-                    )),
+                    0 => {
+                        ::core::result::Result::Ok(Artifact(
+                            ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                                self.builder.get_pointer_field(3),
+                                ::core::option::Option::None,
+                            ),
+                        ))
+                    }
                     1 => ::core::result::Result::Ok(None(())),
                     x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
                 }
@@ -4457,30 +4477,38 @@ pub mod asset_change_event {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichReader<'a>, ::capnp::NotInSchema> {
             match self.reader.get_data_field::<u16>(0) {
-                0 => ::core::result::Result::Ok(ContentUpdateEvent(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                1 => ::core::result::Result::Ok(RemoveEvent(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                2 => ::core::result::Result::Ok(PathUpdateEvent(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                3 => ::core::result::Result::Ok(PathRemoveEvent(
-                    ::capnp::traits::FromPointerReader::get_from_pointer(
-                        &self.reader.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(ContentUpdateEvent(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                1 => {
+                    ::core::result::Result::Ok(RemoveEvent(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                2 => {
+                    ::core::result::Result::Ok(PathUpdateEvent(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                3 => {
+                    ::core::result::Result::Ok(PathRemoveEvent(
+                        ::capnp::traits::FromPointerReader::get_from_pointer(
+                            &self.reader.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
         }
@@ -4652,30 +4680,38 @@ pub mod asset_change_event {
         #[inline]
         pub fn which(self) -> ::core::result::Result<WhichBuilder<'a>, ::capnp::NotInSchema> {
             match self.builder.get_data_field::<u16>(0) {
-                0 => ::core::result::Result::Ok(ContentUpdateEvent(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                1 => ::core::result::Result::Ok(RemoveEvent(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                2 => ::core::result::Result::Ok(PathUpdateEvent(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
-                3 => ::core::result::Result::Ok(PathRemoveEvent(
-                    ::capnp::traits::FromPointerBuilder::get_from_pointer(
-                        self.builder.get_pointer_field(0),
-                        ::core::option::Option::None,
-                    ),
-                )),
+                0 => {
+                    ::core::result::Result::Ok(ContentUpdateEvent(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                1 => {
+                    ::core::result::Result::Ok(RemoveEvent(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                2 => {
+                    ::core::result::Result::Ok(PathUpdateEvent(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
+                3 => {
+                    ::core::result::Result::Ok(PathRemoveEvent(
+                        ::capnp::traits::FromPointerBuilder::get_from_pointer(
+                            self.builder.get_pointer_field(0),
+                            ::core::option::Option::None,
+                        ),
+                    ))
+                }
                 x => ::core::result::Result::Err(::capnp::NotInSchema(x)),
             }
         }

--- a/schema/src/schemas/pack_capnp.rs
+++ b/schema/src/schemas/pack_capnp.rs
@@ -6,12 +6,12 @@ pub mod pack_file_entry {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -66,6 +66,7 @@ pub mod pack_file_entry {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_artifact(self) -> ::capnp::Result<crate::data_capnp::artifact::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -73,9 +74,11 @@ pub mod pack_file_entry {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_artifact(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_asset_metadata(
             self,
@@ -85,9 +88,11 @@ pub mod pack_file_entry {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_asset_metadata(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -95,6 +100,7 @@ pub mod pack_file_entry {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_path(&self) -> bool {
             !self.reader.get_pointer_field(2).is_null()
         }
@@ -135,6 +141,7 @@ pub mod pack_file_entry {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -159,9 +166,11 @@ pub mod pack_file_entry {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -169,6 +178,7 @@ pub mod pack_file_entry {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_artifact(self) -> ::capnp::Result<crate::data_capnp::artifact::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -176,6 +186,7 @@ pub mod pack_file_entry {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_artifact(
             &mut self,
@@ -187,13 +198,16 @@ pub mod pack_file_entry {
                 false,
             )
         }
+
         #[inline]
         pub fn init_artifact(self) -> crate::data_capnp::artifact::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_artifact(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_asset_metadata(
             self,
@@ -203,6 +217,7 @@ pub mod pack_file_entry {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_asset_metadata(
             &mut self,
@@ -214,13 +229,16 @@ pub mod pack_file_entry {
                 false,
             )
         }
+
         #[inline]
         pub fn init_asset_metadata(self) -> crate::data_capnp::asset_metadata::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
         }
+
         pub fn has_asset_metadata(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -228,14 +246,17 @@ pub mod pack_file_entry {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(2).set_data(value);
         }
+
         #[inline]
         pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(2).init_data(size)
         }
+
         pub fn has_path(&self) -> bool {
             !self.builder.get_pointer_field(2).is_null()
         }
@@ -255,6 +276,7 @@ pub mod pack_file_entry {
         pub fn get_artifact(&self) -> crate::data_capnp::artifact::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
         }
+
         pub fn get_asset_metadata(&self) -> crate::data_capnp::asset_metadata::Pipeline {
             ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
         }
@@ -273,12 +295,12 @@ pub mod pack_file {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -333,6 +355,7 @@ pub mod pack_file {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_entries(
             self,
@@ -344,6 +367,7 @@ pub mod pack_file {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_entries(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
@@ -384,6 +408,7 @@ pub mod pack_file {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -408,9 +433,11 @@ pub mod pack_file {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -418,6 +445,7 @@ pub mod pack_file {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_entries(
             self,
@@ -429,6 +457,7 @@ pub mod pack_file {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_entries(
             &mut self,
@@ -440,6 +469,7 @@ pub mod pack_file {
                 false,
             )
         }
+
         #[inline]
         pub fn init_entries(
             self,
@@ -450,6 +480,7 @@ pub mod pack_file {
                 size,
             )
         }
+
         pub fn has_entries(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }

--- a/schema/src/schemas/service_capnp.rs
+++ b/schema/src/schemas/service_capnp.rs
@@ -823,15 +823,19 @@ pub mod asset_hub {
             results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
         ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
             match interface_id {
-                _private::TYPE_ID => ServerDispatch::<_T>::dispatch_call_internal(
-                    &mut self.server,
-                    method_id,
-                    params,
-                    results,
-                ),
-                _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
-                    "Method not implemented.".to_string(),
-                )),
+                _private::TYPE_ID => {
+                    ServerDispatch::<_T>::dispatch_call_internal(
+                        &mut self.server,
+                        method_id,
+                        params,
+                        results,
+                    )
+                }
+                _ => {
+                    ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                        "Method not implemented.".to_string(),
+                    ))
+                }
             }
         }
     }
@@ -843,17 +847,23 @@ pub mod asset_hub {
             results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
         ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
             match method_id {
-                0 => server.register_listener(
-                    ::capnp::private::capability::internal_get_typed_params(params),
-                    ::capnp::private::capability::internal_get_typed_results(results),
-                ),
-                1 => server.get_snapshot(
-                    ::capnp::private::capability::internal_get_typed_params(params),
-                    ::capnp::private::capability::internal_get_typed_results(results),
-                ),
-                _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
-                    "Method not implemented.".to_string(),
-                )),
+                0 => {
+                    server.register_listener(
+                        ::capnp::private::capability::internal_get_typed_params(params),
+                        ::capnp::private::capability::internal_get_typed_results(results),
+                    )
+                }
+                1 => {
+                    server.get_snapshot(
+                        ::capnp::private::capability::internal_get_typed_params(params),
+                        ::capnp::private::capability::internal_get_typed_results(results),
+                    )
+                }
+                _ => {
+                    ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                        "Method not implemented.".to_string(),
+                    ))
+                }
             }
         }
     }
@@ -1233,15 +1243,19 @@ pub mod asset_hub {
                 results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
             ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
                 match interface_id {
-                    _private::TYPE_ID => ServerDispatch::<_T>::dispatch_call_internal(
-                        &mut self.server,
-                        method_id,
-                        params,
-                        results,
-                    ),
-                    _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
-                        "Method not implemented.".to_string(),
-                    )),
+                    _private::TYPE_ID => {
+                        ServerDispatch::<_T>::dispatch_call_internal(
+                            &mut self.server,
+                            method_id,
+                            params,
+                            results,
+                        )
+                    }
+                    _ => {
+                        ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                            "Method not implemented.".to_string(),
+                        ))
+                    }
                 }
             }
         }
@@ -1253,57 +1267,83 @@ pub mod asset_hub {
                 results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
             ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
                 match method_id {
-                    0 => server.get_asset_metadata(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    1 => server.get_asset_metadata_with_dependencies(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    2 => server.get_all_asset_metadata(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    3 => server.get_latest_asset_change(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    4 => server.get_asset_changes(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    5 => server.get_import_artifacts(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    6 => server.update_asset(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    7 => server.patch_asset(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    8 => server.get_path_for_assets(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    9 => server.get_assets_for_paths(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    10 => server.create_file(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    11 => server.delete_file(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
-                        "Method not implemented.".to_string(),
-                    )),
+                    0 => {
+                        server.get_asset_metadata(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    1 => {
+                        server.get_asset_metadata_with_dependencies(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    2 => {
+                        server.get_all_asset_metadata(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    3 => {
+                        server.get_latest_asset_change(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    4 => {
+                        server.get_asset_changes(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    5 => {
+                        server.get_import_artifacts(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    6 => {
+                        server.update_asset(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    7 => {
+                        server.patch_asset(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    8 => {
+                        server.get_path_for_assets(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    9 => {
+                        server.get_assets_for_paths(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    10 => {
+                        server.create_file(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    11 => {
+                        server.delete_file(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    _ => {
+                        ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                            "Method not implemented.".to_string(),
+                        ))
+                    }
                 }
             }
         }
@@ -6293,15 +6333,19 @@ pub mod asset_hub {
                 results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
             ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
                 match interface_id {
-                    _private::TYPE_ID => ServerDispatch::<_T>::dispatch_call_internal(
-                        &mut self.server,
-                        method_id,
-                        params,
-                        results,
-                    ),
-                    _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
-                        "Method not implemented.".to_string(),
-                    )),
+                    _private::TYPE_ID => {
+                        ServerDispatch::<_T>::dispatch_call_internal(
+                            &mut self.server,
+                            method_id,
+                            params,
+                            results,
+                        )
+                    }
+                    _ => {
+                        ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                            "Method not implemented.".to_string(),
+                        ))
+                    }
                 }
             }
         }
@@ -6313,13 +6357,17 @@ pub mod asset_hub {
                 results: ::capnp::capability::Results<::capnp::any_pointer::Owned>,
             ) -> ::capnp::capability::Promise<(), ::capnp::Error> {
                 match method_id {
-                    0 => server.update(
-                        ::capnp::private::capability::internal_get_typed_params(params),
-                        ::capnp::private::capability::internal_get_typed_results(results),
-                    ),
-                    _ => ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
-                        "Method not implemented.".to_string(),
-                    )),
+                    0 => {
+                        server.update(
+                            ::capnp::private::capability::internal_get_typed_params(params),
+                            ::capnp::private::capability::internal_get_typed_results(results),
+                        )
+                    }
+                    _ => {
+                        ::capnp::capability::Promise::err(::capnp::Error::unimplemented(
+                            "Method not implemented.".to_string(),
+                        ))
+                    }
                 }
             }
         }

--- a/schema/src/schemas/service_capnp.rs
+++ b/schema/src/schemas/service_capnp.rs
@@ -6,12 +6,12 @@ pub mod asset_path {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -66,6 +66,7 @@ pub mod asset_path {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -73,9 +74,11 @@ pub mod asset_path {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_id(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -83,6 +86,7 @@ pub mod asset_path {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_path(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -123,6 +127,7 @@ pub mod asset_path {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -147,9 +152,11 @@ pub mod asset_path {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -157,6 +164,7 @@ pub mod asset_path {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_id(self) -> ::capnp::Result<crate::data_capnp::asset_uuid::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -164,6 +172,7 @@ pub mod asset_path {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_id(
             &mut self,
@@ -175,13 +184,16 @@ pub mod asset_path {
                 false,
             )
         }
+
         #[inline]
         pub fn init_id(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
             ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
         }
+
         pub fn has_id(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -189,14 +201,17 @@ pub mod asset_path {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_path(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -231,12 +246,12 @@ pub mod path_assets {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -291,6 +306,7 @@ pub mod path_assets {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -298,9 +314,11 @@ pub mod path_assets {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_path(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_assets(
             self,
@@ -311,6 +329,7 @@ pub mod path_assets {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_assets(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -351,6 +370,7 @@ pub mod path_assets {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -375,9 +395,11 @@ pub mod path_assets {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -385,6 +407,7 @@ pub mod path_assets {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -392,17 +415,21 @@ pub mod path_assets {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_path(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_assets(
             self,
@@ -413,6 +440,7 @@ pub mod path_assets {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_assets(
             &mut self,
@@ -424,6 +452,7 @@ pub mod path_assets {
                 false,
             )
         }
+
         #[inline]
         pub fn init_assets(
             self,
@@ -434,6 +463,7 @@ pub mod path_assets {
                 size,
             )
         }
+
         pub fn has_assets(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -464,12 +494,12 @@ pub mod asset_data {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-        type Reader = Reader<'a>;
         type Builder = Builder<'a>;
+        type Reader = Reader<'a>;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Pipeline;
@@ -524,6 +554,7 @@ pub mod asset_data {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.reader.total_size()
         }
+
         #[inline]
         pub fn get_data(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -531,9 +562,11 @@ pub mod asset_data {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_data(&self) -> bool {
             !self.reader.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_type_id(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
             ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -541,6 +574,7 @@ pub mod asset_data {
                 ::core::option::Option::None,
             )
         }
+
         pub fn has_type_id(&self) -> bool {
             !self.reader.get_pointer_field(1).is_null()
         }
@@ -581,6 +615,7 @@ pub mod asset_data {
         ) -> Builder<'a> {
             ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             default: ::core::option::Option<&'a [capnp::Word]>,
@@ -605,9 +640,11 @@ pub mod asset_data {
         pub fn into_reader(self) -> Reader<'a> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
+
         pub fn reborrow(&mut self) -> Builder<'_> {
             Builder { ..*self }
         }
+
         pub fn reborrow_as_reader(&self) -> Reader<'_> {
             ::capnp::traits::FromStructReader::new(self.builder.into_reader())
         }
@@ -615,6 +652,7 @@ pub mod asset_data {
         pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
             self.builder.into_reader().total_size()
         }
+
         #[inline]
         pub fn get_data(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -622,17 +660,21 @@ pub mod asset_data {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_data(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(0).set_data(value);
         }
+
         #[inline]
         pub fn init_data(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(0).init_data(size)
         }
+
         pub fn has_data(&self) -> bool {
             !self.builder.get_pointer_field(0).is_null()
         }
+
         #[inline]
         pub fn get_type_id(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
             ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -640,14 +682,17 @@ pub mod asset_data {
                 ::core::option::Option::None,
             )
         }
+
         #[inline]
         pub fn set_type_id(&mut self, value: ::capnp::data::Reader<'_>) {
             self.builder.get_pointer_field(1).set_data(value);
         }
+
         #[inline]
         pub fn init_type_id(self, size: u32) -> ::capnp::data::Builder<'a> {
             self.builder.get_pointer_field(1).init_data(size)
         }
+
         pub fn has_type_id(&self) -> bool {
             !self.builder.get_pointer_field(1).is_null()
         }
@@ -700,8 +745,8 @@ pub mod asset_hub {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl<'a> ::capnp::traits::Owned<'a> for Owned {
-        type Reader = Client;
         type Builder = Client;
+        type Reader = Client;
     }
     impl ::capnp::traits::Pipelined for Owned {
         type Pipeline = Client;
@@ -723,6 +768,7 @@ pub mod asset_hub {
         ) -> Client {
             unimplemented!()
         }
+
         fn get_from_pointer(
             builder: ::capnp::private::layout::PointerBuilder<'a>,
             _default: ::core::option::Option<&'a [capnp::Word]>,
@@ -765,6 +811,7 @@ pub mod asset_hub {
         > {
             self.client.new_call(_private::TYPE_ID, 0, None)
         }
+
         pub fn get_snapshot_request(
             &self,
         ) -> ::capnp::capability::Request<
@@ -799,12 +846,14 @@ pub mod asset_hub {
     }
     impl<_S: Server + 'static> ::capnp::capability::FromServer<_S> for Client {
         type Dispatch = ServerDispatch<_S>;
+
         fn from_server(s: _S) -> ServerDispatch<_S> {
             ServerDispatch { server: s }
         }
     }
     impl<_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
         type Target = _T;
+
         fn deref(&self) -> &_T {
             &self.server
         }
@@ -955,8 +1004,8 @@ pub mod asset_hub {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Client;
             type Builder = Client;
+            type Reader = Client;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Client;
@@ -978,6 +1027,7 @@ pub mod asset_hub {
             ) -> Client {
                 unimplemented!()
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 _default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1020,9 +1070,11 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 0, None)
             }
+
             pub fn get_asset_metadata_with_dependencies_request(&self) -> ::capnp::capability::Request<crate::service_capnp::asset_hub::snapshot::get_asset_metadata_with_dependencies_params::Owned,crate::service_capnp::asset_hub::snapshot::get_asset_metadata_with_dependencies_results::Owned>{
                 self.client.new_call(_private::TYPE_ID, 1, None)
             }
+
             pub fn get_all_asset_metadata_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1031,6 +1083,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 2, None)
             }
+
             pub fn get_latest_asset_change_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1039,6 +1092,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 3, None)
             }
+
             pub fn get_asset_changes_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1047,6 +1101,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 4, None)
             }
+
             pub fn get_import_artifacts_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1055,6 +1110,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 5, None)
             }
+
             pub fn update_asset_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1063,6 +1119,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 6, None)
             }
+
             pub fn patch_asset_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1071,6 +1128,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 7, None)
             }
+
             pub fn get_path_for_assets_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1079,6 +1137,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 8, None)
             }
+
             pub fn get_assets_for_paths_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1087,6 +1146,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 9, None)
             }
+
             pub fn create_file_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1095,6 +1155,7 @@ pub mod asset_hub {
             > {
                 self.client.new_call(_private::TYPE_ID, 10, None)
             }
+
             pub fn delete_file_request(
                 &self,
             ) -> ::capnp::capability::Request<
@@ -1219,12 +1280,14 @@ pub mod asset_hub {
         }
         impl<_S: Server + 'static> ::capnp::capability::FromServer<_S> for Client {
             type Dispatch = ServerDispatch<_S>;
+
             fn from_server(s: _S) -> ServerDispatch<_S> {
                 ServerDispatch { server: s }
             }
         }
         impl<_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
             type Target = _T;
+
             fn deref(&self) -> &_T {
                 &self.server
             }
@@ -1355,12 +1418,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -1415,6 +1478,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -1426,6 +1490,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -1468,6 +1533,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1492,9 +1558,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -1502,6 +1570,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -1513,6 +1582,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -1524,6 +1594,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -1535,6 +1606,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -1565,12 +1637,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -1625,6 +1697,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -1636,6 +1709,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -1678,6 +1752,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1702,9 +1777,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -1712,6 +1789,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -1723,6 +1801,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -1737,6 +1816,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -1748,6 +1828,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -1778,12 +1859,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -1838,6 +1919,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -1849,6 +1931,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -1891,6 +1974,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -1915,9 +1999,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -1925,6 +2011,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -1936,6 +2023,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -1947,6 +2035,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -1958,6 +2047,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -1988,12 +2078,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -2048,6 +2138,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -2059,6 +2150,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -2101,6 +2193,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2125,9 +2218,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -2135,6 +2230,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -2146,6 +2242,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -2160,6 +2257,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -2171,6 +2269,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -2201,12 +2300,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -2300,6 +2399,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2324,9 +2424,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -2361,12 +2463,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -2421,6 +2523,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -2432,6 +2535,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -2474,6 +2578,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2498,9 +2603,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -2508,6 +2615,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -2519,6 +2627,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -2533,6 +2642,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -2544,6 +2654,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -2574,12 +2685,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -2673,6 +2784,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2697,9 +2809,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -2734,12 +2848,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -2794,6 +2908,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_num(self) -> u64 {
                     self.reader.get_data_field::<u64>(0)
@@ -2837,6 +2952,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -2861,9 +2977,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -2871,10 +2989,12 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_num(self) -> u64 {
                     self.builder.get_data_field::<u64>(0)
                 }
+
                 #[inline]
                 pub fn set_num(&mut self, value: u64) {
                     self.builder.set_data_field::<u64>(0, value);
@@ -2906,12 +3026,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -2966,10 +3086,12 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_start(self) -> u64 {
                     self.reader.get_data_field::<u64>(0)
                 }
+
                 #[inline]
                 pub fn get_count(self) -> u64 {
                     self.reader.get_data_field::<u64>(1)
@@ -3013,6 +3135,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3037,9 +3160,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -3047,18 +3172,22 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_start(self) -> u64 {
                     self.builder.get_data_field::<u64>(0)
                 }
+
                 #[inline]
                 pub fn set_start(&mut self, value: u64) {
                     self.builder.set_data_field::<u64>(0, value);
                 }
+
                 #[inline]
                 pub fn get_count(self) -> u64 {
                     self.builder.get_data_field::<u64>(1)
                 }
+
                 #[inline]
                 pub fn set_count(&mut self, value: u64) {
                     self.builder.set_data_field::<u64>(1, value);
@@ -3090,12 +3219,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -3150,6 +3279,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_changes(
                     self,
@@ -3164,6 +3294,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_changes(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -3206,6 +3337,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3230,9 +3362,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -3240,6 +3374,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_changes(
                     self,
@@ -3254,6 +3389,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_changes(
                     &mut self,
@@ -3268,6 +3404,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_changes(
                     self,
@@ -3281,6 +3418,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_changes(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -3311,12 +3449,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -3371,6 +3509,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -3382,6 +3521,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -3424,6 +3564,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3448,9 +3589,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -3458,6 +3601,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -3469,6 +3613,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -3480,6 +3625,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -3491,6 +3637,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -3521,12 +3668,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -3581,6 +3728,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_artifacts(
                     self,
@@ -3592,6 +3740,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_artifacts(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -3634,6 +3783,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3658,9 +3808,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -3668,6 +3820,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_artifacts(
                     self,
@@ -3679,6 +3832,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_artifacts(
                     &mut self,
@@ -3690,6 +3844,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_artifacts(
                     self,
@@ -3701,6 +3856,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_artifacts(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -3731,12 +3887,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -3791,6 +3947,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_asset(self) -> ::capnp::Result<crate::data_capnp::artifact::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -3798,6 +3955,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_asset(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -3840,6 +3998,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -3864,9 +4023,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -3874,6 +4035,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_asset(
                     self,
@@ -3883,6 +4045,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_asset(
                     &mut self,
@@ -3894,6 +4057,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_asset(self) -> crate::data_capnp::artifact::Builder<'a> {
                     ::capnp::traits::FromPointerBuilder::init_pointer(
@@ -3901,6 +4065,7 @@ pub mod asset_hub {
                         0,
                     )
                 }
+
                 pub fn has_asset(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -3937,12 +4102,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -3997,6 +4162,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_new_import_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -4004,6 +4170,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_new_import_hash(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -4046,6 +4213,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4070,9 +4238,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -4080,6 +4250,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_new_import_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -4087,14 +4258,17 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_new_import_hash(&mut self, value: ::capnp::data::Reader<'_>) {
                     self.builder.get_pointer_field(0).set_data(value);
                 }
+
                 #[inline]
                 pub fn init_new_import_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
                     self.builder.get_pointer_field(0).init_data(size)
                 }
+
                 pub fn has_new_import_hash(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -4125,12 +4299,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -4185,6 +4359,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_asset_id(
                     self,
@@ -4194,9 +4369,11 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_asset_id(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
+
                 #[inline]
                 pub fn get_asset_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -4204,9 +4381,11 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_asset_hash(&self) -> bool {
                     !self.reader.get_pointer_field(1).is_null()
                 }
+
                 #[inline]
                 pub fn get_patch(
                     self,
@@ -4216,6 +4395,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_patch(&self) -> bool {
                     !self.reader.get_pointer_field(2).is_null()
                 }
@@ -4258,6 +4438,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4282,9 +4463,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -4292,6 +4475,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_asset_id(
                     self,
@@ -4301,6 +4485,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_asset_id(
                     &mut self,
@@ -4312,6 +4497,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_asset_id(self) -> crate::data_capnp::asset_uuid::Builder<'a> {
                     ::capnp::traits::FromPointerBuilder::init_pointer(
@@ -4319,9 +4505,11 @@ pub mod asset_hub {
                         0,
                     )
                 }
+
                 pub fn has_asset_id(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
+
                 #[inline]
                 pub fn get_asset_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -4329,17 +4517,21 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_asset_hash(&mut self, value: ::capnp::data::Reader<'_>) {
                     self.builder.get_pointer_field(1).set_data(value);
                 }
+
                 #[inline]
                 pub fn init_asset_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
                     self.builder.get_pointer_field(1).init_data(size)
                 }
+
                 pub fn has_asset_hash(&self) -> bool {
                     !self.builder.get_pointer_field(1).is_null()
                 }
+
                 #[inline]
                 pub fn get_patch(
                     self,
@@ -4350,6 +4542,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_patch(
                     &mut self,
@@ -4361,6 +4554,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_patch(self) -> crate::service_capnp::asset_data::Builder<'a> {
                     ::capnp::traits::FromPointerBuilder::init_pointer(
@@ -4368,6 +4562,7 @@ pub mod asset_hub {
                         0,
                     )
                 }
+
                 pub fn has_patch(&self) -> bool {
                     !self.builder.get_pointer_field(2).is_null()
                 }
@@ -4389,6 +4584,7 @@ pub mod asset_hub {
                         self._typeless.get_pointer_field(0),
                     )
                 }
+
                 pub fn get_patch(&self) -> crate::service_capnp::asset_data::Pipeline {
                     ::capnp::capability::FromTypelessPipeline::new(
                         self._typeless.get_pointer_field(2),
@@ -4409,12 +4605,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -4469,6 +4665,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_new_import_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -4476,6 +4673,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_new_import_hash(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -4518,6 +4716,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4542,9 +4741,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -4552,6 +4753,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_new_import_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -4559,14 +4761,17 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_new_import_hash(&mut self, value: ::capnp::data::Reader<'_>) {
                     self.builder.get_pointer_field(0).set_data(value);
                 }
+
                 #[inline]
                 pub fn init_new_import_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
                     self.builder.get_pointer_field(0).init_data(size)
                 }
+
                 pub fn has_new_import_hash(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -4597,12 +4802,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -4657,6 +4862,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -4668,6 +4874,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -4710,6 +4917,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4734,9 +4942,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -4744,6 +4954,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -4755,6 +4966,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -4766,6 +4978,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -4777,6 +4990,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -4807,12 +5021,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -4867,6 +5081,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_paths(
                     self,
@@ -4878,6 +5093,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_paths(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -4920,6 +5136,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -4944,9 +5161,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -4954,6 +5173,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_paths(
                     self,
@@ -4965,6 +5185,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_paths(
                     &mut self,
@@ -4979,6 +5200,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_paths(
                     self,
@@ -4990,6 +5212,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_paths(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -5020,12 +5243,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -5080,6 +5303,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_paths(self) -> ::capnp::Result<::capnp::data_list::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5087,6 +5311,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_paths(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -5129,6 +5354,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5153,9 +5379,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -5163,6 +5391,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_paths(self) -> ::capnp::Result<::capnp::data_list::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -5170,6 +5399,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_paths(
                     &mut self,
@@ -5181,6 +5411,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_paths(self, size: u32) -> ::capnp::data_list::Builder<'a> {
                     ::capnp::traits::FromPointerBuilder::init_pointer(
@@ -5188,6 +5419,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_paths(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -5218,12 +5450,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -5278,6 +5510,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -5289,6 +5522,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -5331,6 +5565,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5355,9 +5590,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -5365,6 +5602,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -5376,6 +5614,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -5390,6 +5629,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -5401,6 +5641,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -5431,12 +5672,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -5491,6 +5732,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5498,9 +5740,11 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_path(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -5512,6 +5756,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.reader.get_pointer_field(1).is_null()
                 }
@@ -5554,6 +5799,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5578,9 +5824,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -5588,6 +5836,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -5595,17 +5844,21 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
                     self.builder.get_pointer_field(0).set_data(value);
                 }
+
                 #[inline]
                 pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
                     self.builder.get_pointer_field(0).init_data(size)
                 }
+
                 pub fn has_path(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
+
                 #[inline]
                 pub fn get_assets(
                     self,
@@ -5617,6 +5870,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_assets(
                     &mut self,
@@ -5631,6 +5885,7 @@ pub mod asset_hub {
                         false,
                     )
                 }
+
                 #[inline]
                 pub fn init_assets(
                     self,
@@ -5642,6 +5897,7 @@ pub mod asset_hub {
                         size,
                     )
                 }
+
                 pub fn has_assets(&self) -> bool {
                     !self.builder.get_pointer_field(1).is_null()
                 }
@@ -5672,12 +5928,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -5732,6 +5988,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_new_import_hash(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5739,6 +5996,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_new_import_hash(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -5781,6 +6039,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5805,9 +6064,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -5815,6 +6076,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_new_import_hash(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -5822,14 +6084,17 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_new_import_hash(&mut self, value: ::capnp::data::Reader<'_>) {
                     self.builder.get_pointer_field(0).set_data(value);
                 }
+
                 #[inline]
                 pub fn init_new_import_hash(self, size: u32) -> ::capnp::data::Builder<'a> {
                     self.builder.get_pointer_field(0).init_data(size)
                 }
+
                 pub fn has_new_import_hash(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -5860,12 +6125,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -5920,6 +6185,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_path(self) -> ::capnp::Result<::capnp::data::Reader<'a>> {
                     ::capnp::traits::FromPointerReader::get_from_pointer(
@@ -5927,6 +6193,7 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 pub fn has_path(&self) -> bool {
                     !self.reader.get_pointer_field(0).is_null()
                 }
@@ -5969,6 +6236,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -5993,9 +6261,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -6003,6 +6273,7 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_path(self) -> ::capnp::Result<::capnp::data::Builder<'a>> {
                     ::capnp::traits::FromPointerBuilder::get_from_pointer(
@@ -6010,14 +6281,17 @@ pub mod asset_hub {
                         ::core::option::Option::None,
                     )
                 }
+
                 #[inline]
                 pub fn set_path(&mut self, value: ::capnp::data::Reader<'_>) {
                     self.builder.get_pointer_field(0).set_data(value);
                 }
+
                 #[inline]
                 pub fn init_path(self, size: u32) -> ::capnp::data::Builder<'a> {
                     self.builder.get_pointer_field(0).init_data(size)
                 }
+
                 pub fn has_path(&self) -> bool {
                     !self.builder.get_pointer_field(0).is_null()
                 }
@@ -6048,12 +6322,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -6147,6 +6421,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -6171,9 +6446,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -6227,8 +6504,8 @@ pub mod asset_hub {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Client;
             type Builder = Client;
+            type Reader = Client;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Client;
@@ -6250,6 +6527,7 @@ pub mod asset_hub {
             ) -> Client {
                 unimplemented!()
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 _default: ::core::option::Option<&'a [capnp::Word]>,
@@ -6309,12 +6587,14 @@ pub mod asset_hub {
         }
         impl<_S: Server + 'static> ::capnp::capability::FromServer<_S> for Client {
             type Dispatch = ServerDispatch<_S>;
+
             fn from_server(s: _S) -> ServerDispatch<_S> {
                 ServerDispatch { server: s }
             }
         }
         impl<_T: Server> ::core::ops::Deref for ServerDispatch<_T> {
             type Target = _T;
+
             fn deref(&self) -> &_T {
                 &self.server
             }
@@ -6379,12 +6659,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -6439,10 +6719,12 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.reader.total_size()
                 }
+
                 #[inline]
                 pub fn get_latest_change(self) -> u64 {
                     self.reader.get_data_field::<u64>(0)
                 }
+
                 #[inline]
                 pub fn get_snapshot(
                     self,
@@ -6494,6 +6776,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -6518,9 +6801,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -6528,14 +6813,17 @@ pub mod asset_hub {
                 pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                     self.builder.into_reader().total_size()
                 }
+
                 #[inline]
                 pub fn get_latest_change(self) -> u64 {
                     self.builder.get_data_field::<u64>(0)
                 }
+
                 #[inline]
                 pub fn set_latest_change(&mut self, value: u64) {
                     self.builder.set_data_field::<u64>(0, value);
                 }
+
                 #[inline]
                 pub fn get_snapshot(
                     self,
@@ -6548,6 +6836,7 @@ pub mod asset_hub {
                         ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                     }
                 }
+
                 #[inline]
                 pub fn set_snapshot(
                     &mut self,
@@ -6590,12 +6879,12 @@ pub mod asset_hub {
             #[derive(Copy, Clone)]
             pub struct Owned(());
             impl<'a> ::capnp::traits::Owned<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-                type Reader = Reader<'a>;
                 type Builder = Builder<'a>;
+                type Reader = Reader<'a>;
             }
             impl ::capnp::traits::Pipelined for Owned {
                 type Pipeline = Pipeline;
@@ -6689,6 +6978,7 @@ pub mod asset_hub {
                         builder.init_struct(_private::STRUCT_SIZE),
                     )
                 }
+
                 fn get_from_pointer(
                     builder: ::capnp::private::layout::PointerBuilder<'a>,
                     default: ::core::option::Option<&'a [capnp::Word]>,
@@ -6713,9 +7003,11 @@ pub mod asset_hub {
                 pub fn into_reader(self) -> Reader<'a> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
+
                 pub fn reborrow(&mut self) -> Builder<'_> {
                     Builder { ..*self }
                 }
+
                 pub fn reborrow_as_reader(&self) -> Reader<'_> {
                     ::capnp::traits::FromStructReader::new(self.builder.into_reader())
                 }
@@ -6751,12 +7043,12 @@ pub mod asset_hub {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Pipeline;
@@ -6811,6 +7103,7 @@ pub mod asset_hub {
             pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                 self.reader.total_size()
             }
+
             #[inline]
             pub fn get_listener(
                 self,
@@ -6859,6 +7152,7 @@ pub mod asset_hub {
             ) -> Builder<'a> {
                 ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 default: ::core::option::Option<&'a [capnp::Word]>,
@@ -6883,9 +7177,11 @@ pub mod asset_hub {
             pub fn into_reader(self) -> Reader<'a> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
+
             pub fn reborrow(&mut self) -> Builder<'_> {
                 Builder { ..*self }
             }
+
             pub fn reborrow_as_reader(&self) -> Reader<'_> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
@@ -6893,6 +7189,7 @@ pub mod asset_hub {
             pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                 self.builder.into_reader().total_size()
             }
+
             #[inline]
             pub fn get_listener(
                 self,
@@ -6904,6 +7201,7 @@ pub mod asset_hub {
                     ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                 }
             }
+
             #[inline]
             pub fn set_listener(
                 &mut self,
@@ -6946,12 +7244,12 @@ pub mod asset_hub {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Pipeline;
@@ -7043,6 +7341,7 @@ pub mod asset_hub {
             ) -> Builder<'a> {
                 ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 default: ::core::option::Option<&'a [capnp::Word]>,
@@ -7067,9 +7366,11 @@ pub mod asset_hub {
             pub fn into_reader(self) -> Reader<'a> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
+
             pub fn reborrow(&mut self) -> Builder<'_> {
                 Builder { ..*self }
             }
+
             pub fn reborrow_as_reader(&self) -> Reader<'_> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
@@ -7104,12 +7405,12 @@ pub mod asset_hub {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Pipeline;
@@ -7201,6 +7502,7 @@ pub mod asset_hub {
             ) -> Builder<'a> {
                 ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 default: ::core::option::Option<&'a [capnp::Word]>,
@@ -7225,9 +7527,11 @@ pub mod asset_hub {
             pub fn into_reader(self) -> Reader<'a> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
+
             pub fn reborrow(&mut self) -> Builder<'_> {
                 Builder { ..*self }
             }
+
             pub fn reborrow_as_reader(&self) -> Reader<'_> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
@@ -7262,12 +7566,12 @@ pub mod asset_hub {
         #[derive(Copy, Clone)]
         pub struct Owned(());
         impl<'a> ::capnp::traits::Owned<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl<'a> ::capnp::traits::OwnedStruct<'a> for Owned {
-            type Reader = Reader<'a>;
             type Builder = Builder<'a>;
+            type Reader = Reader<'a>;
         }
         impl ::capnp::traits::Pipelined for Owned {
             type Pipeline = Pipeline;
@@ -7322,6 +7626,7 @@ pub mod asset_hub {
             pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                 self.reader.total_size()
             }
+
             #[inline]
             pub fn get_snapshot(
                 self,
@@ -7370,6 +7675,7 @@ pub mod asset_hub {
             ) -> Builder<'a> {
                 ::capnp::traits::FromStructBuilder::new(builder.init_struct(_private::STRUCT_SIZE))
             }
+
             fn get_from_pointer(
                 builder: ::capnp::private::layout::PointerBuilder<'a>,
                 default: ::core::option::Option<&'a [capnp::Word]>,
@@ -7394,9 +7700,11 @@ pub mod asset_hub {
             pub fn into_reader(self) -> Reader<'a> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
+
             pub fn reborrow(&mut self) -> Builder<'_> {
                 Builder { ..*self }
             }
+
             pub fn reborrow_as_reader(&self) -> Reader<'_> {
                 ::capnp::traits::FromStructReader::new(self.builder.into_reader())
             }
@@ -7404,6 +7712,7 @@ pub mod asset_hub {
             pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
                 self.builder.into_reader().total_size()
             }
+
             #[inline]
             pub fn get_snapshot(
                 self,
@@ -7415,6 +7724,7 @@ pub mod asset_hub {
                     ::core::result::Result::Err(e) => ::core::result::Result::Err(e),
                 }
             }
+
             #[inline]
             pub fn set_snapshot(
                 &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod tests {
             load_op.complete();
             Ok(())
         }
+
         fn commit_asset_version(
             &self,
             _asset_type: &AssetTypeId,
@@ -96,6 +97,7 @@ mod tests {
             state.commit_version = Some(version);
             state.load_version = None;
         }
+
         fn free(&self, _asset_type: &AssetTypeId, loader_handle: LoadHandle, _version: u32) {
             println!("free asset {:?}", loader_handle);
             self.map.write().unwrap().remove(&loader_handle);
@@ -134,8 +136,8 @@ mod tests {
     #[uuid = "fa50e08c-af6c-4ada-aed1-447c116d63bc"]
     struct TxtImporter;
     impl AsyncImporter for TxtImporter {
-        type State = TxtImporterState;
         type Options = TxtFormat;
+        type State = TxtImporterState;
 
         fn version_static() -> u32
         where
@@ -143,6 +145,7 @@ mod tests {
         {
             1
         }
+
         fn version(&self) -> u32 {
             Self::version_static()
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 pub use atelier_core as core;
+use atelier_core::{AssetRef, AssetUuid};
 pub use atelier_daemon as daemon;
 pub use atelier_importer as importer;
 pub use atelier_loader as loader;
-
-use atelier_core::{AssetRef, AssetUuid};
 use atelier_loader::handle::{Handle, SerdeContext};
 
 pub fn make_handle<T>(uuid: AssetUuid) -> Handle<T> {
@@ -25,23 +24,6 @@ pub fn make_handle_from_str<T>(uuid_str: &str) -> Result<Handle<T>, atelier_core
 #[cfg(feature = "type_uuid")]
 #[cfg(test)]
 mod tests {
-    use atelier_core::{type_uuid, type_uuid::TypeUuid, AssetRef, AssetTypeId, AssetUuid};
-    use atelier_daemon::{init_logging, AssetDaemon};
-    use atelier_importer::{
-        AsyncImporter, ImportOp, ImportedAsset, ImporterValue, Result as ImportResult,
-    };
-    use atelier_loader::{
-        rpc_io::RpcIO,
-        storage::DefaultIndirectionResolver,
-        storage::{AssetLoadOp, AssetStorage, LoadStatus, LoaderInfoProvider},
-        LoadHandle, Loader,
-    };
-
-    use futures::future::BoxFuture;
-    use futures::io::AsyncReadExt;
-    use futures::AsyncRead;
-    use serde::{Deserialize, Serialize};
-    use serial_test::serial;
     use std::{
         collections::HashMap,
         iter::FromIterator,
@@ -50,6 +32,22 @@ mod tests {
         string::FromUtf8Error,
         sync::{Once, RwLock},
     };
+
+    use atelier_core::{type_uuid, type_uuid::TypeUuid, AssetRef, AssetTypeId, AssetUuid};
+    use atelier_daemon::{init_logging, AssetDaemon};
+    use atelier_importer::{
+        AsyncImporter, ImportOp, ImportedAsset, ImporterValue, Result as ImportResult,
+    };
+    use atelier_loader::{
+        rpc_io::RpcIO,
+        storage::{
+            AssetLoadOp, AssetStorage, DefaultIndirectionResolver, LoadStatus, LoaderInfoProvider,
+        },
+        LoadHandle, Loader,
+    };
+    use futures::{future::BoxFuture, io::AsyncReadExt, AsyncRead};
+    use serde::{Deserialize, Serialize};
+    use serial_test::serial;
     use uuid::Uuid;
 
     #[derive(Debug)]


### PR DESCRIPTION
This standardizes formatting to the same as in amethyst and will help to keep code style consistent for outside contributors.