### PR TITLE
do not panic on file errors

### DIFF
--- a/daemon/src/file_tracker.rs
+++ b/daemon/src/file_tracker.rs
@@ -678,7 +678,7 @@ impl FileTracker {
                         match events::handle_file_event(&mut txn, &self.tables, file_event, &mut scan_stack) {
                             Ok(Some(evt)) => listeners.send_event(evt),
                             Ok(None) => {},
-                            Err(err) => panic!("Error while handling file event: {}", err),
+                            Err(err) => log::error!("Error while handling file event: {}", err),
                         }
 
                         select! {


### PR DESCRIPTION
I've integrated atelier-assets into a project, and set it up with atelier-daemon as well, a daemon, running permanently in the background. However, I noticed that when editing files the daemon would crash with the following:

```
DEBUG 2021-01-11T09:05:02.332904213+00:00 atelier_daemon::file_tracker::events | file event error: entity not found
thread 'main' panicked at 'Error while handling file event: entity not found', $HOME/.cargo/git/checkouts/atelier-assets-d1ca3eba326dcbbc/ce3c046/daemon/src/file_tracker.rs:672:41
```

I believe that the files that cause these problems are emacs lock files, which are simply dead links with info about the editor. While this likely needs to be handled wherever this file is read, I'd argue that panics should be extremely exceptional in a library, and to me "dead link" isn't that.