### PR TITLE
re-export PackfileReader for symmetry with RpcIO

### DIFF
--- a/loader/src/lib.rs
+++ b/loader/src/lib.rs
@@ -19,6 +19,8 @@ pub mod storage;
 pub use atelier_core::{AssetRef, AssetTypeId, AssetUuid};
 pub use crossbeam_channel;
 pub use loader::Loader;
+#[cfg(feature = "packfile_io")]
+pub use packfile_io::PackfileReader;
 #[cfg(feature = "rpc_io")]
 pub use rpc_io::RpcIO;
 pub use storage::LoadHandle;


### PR DESCRIPTION
Very minor, found that the PackfileReader was not re-exported like the RpcIO and spent an embarassing long time before finding the issue. If it's intentional I can update my usage, it was just unexpected.